### PR TITLE
Super Admin - Disable MFA

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1182,6 +1182,13 @@ Users can be managed only by super admins.
     }
     ```
 
+## Disable MFA for User [DELETE /manage/users/{user_id_or_email}/MFA]
+
++ Parameters
+    + user_id_or_email (required) - User id or email
+
++ Response 204
+
 
 # Group Notifications
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1182,6 +1182,32 @@ Users can be managed only by super admins.
     }
     ```
 
+## Enable MFA for User [POST /manage/users/{user_id_or_email}/MFA]
+
++ Parameters
+    + user_id_or_email (required) - User id or email
+
++ Request (application/json)
+
+    ```js
+    {
+        "secret": "secret"
+    }
+    ```
++ Response 200 (application/json)
+
+    ```js
+    {
+        "id": 2,
+        "name": "Corrected Spelling",
+        "email": "spelling@keboola.com",
+        "mfaEnabled": true,
+        "features": [
+            "inline-manual"
+        ]
+    }
+    ```
+
 ## Disable MFA for User [DELETE /manage/users/{user_id_or_email}/MFA]
 
 + Parameters

--- a/apiary.apib
+++ b/apiary.apib
@@ -1182,33 +1182,7 @@ Users can be managed only by super admins.
     }
     ```
 
-## Enable MFA for User [POST /manage/users/{user_id_or_email}/MFA]
-
-+ Parameters
-    + user_id_or_email (required) - User id or email
-
-+ Request (application/json)
-
-    ```js
-    {
-        "secret": "secret"
-    }
-    ```
-+ Response 200 (application/json)
-
-    ```js
-    {
-        "id": 2,
-        "name": "Corrected Spelling",
-        "email": "spelling@keboola.com",
-        "mfaEnabled": true,
-        "features": [
-            "inline-manual"
-        ]
-    }
-    ```
-
-## Disable MFA for User [DELETE /manage/users/{user_id_or_email}/MFA]
+## Disable MFA for User [DELETE /manage/users/{user_id_or_email}/mfa]
 
 + Parameters
     + user_id_or_email (required) - User id or email

--- a/src/Client.php
+++ b/src/Client.php
@@ -378,16 +378,9 @@ class Client
         $this->apiDelete("/manage/users/{$emailOrId}/features/{$feature}");
     }
 
-    public function enableUserMFA($emailOrId, $secret)
-    {
-        $this->apiPost("/manage/users/{$emailOrId}/MFA", [
-            'secret' => $secret
-        ]);
-    }
-
     public function disableUserMFA($emailOrId)
     {
-        $this->apiDelete("/manage/users/{$emailOrId}/MFA");
+        $this->apiDelete("/manage/users/{$emailOrId}/mfa");
     }
 
     public function addNotification($data)

--- a/src/Client.php
+++ b/src/Client.php
@@ -378,6 +378,18 @@ class Client
         $this->apiDelete("/manage/users/{$emailOrId}/features/{$feature}");
     }
 
+    public function enableUserMFA($emailOrId, $secret)
+    {
+        $this->apiPost("/manage/users/{$emailOrId}/MFA", [
+            'secret' => $secret
+        ]);
+    }
+
+    public function disableUserMFA($emailOrId)
+    {
+        $this->apiDelete("/manage/users/{$emailOrId}/MFA");
+    }
+
     public function addNotification($data)
     {
         return $this->apiPost("/manage/notifications", $data);

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -124,29 +124,21 @@ class UsersTest extends ClientTestCase
 
         $user = $this->client->getUser($userId);
 
-        $this->assertArrayHasKey($user, 'mfaEnabled');
+        $this->assertArrayHasKey('mfaEnabled', $user);
         $this->assertFalse($user['mfaEnabled']);
 
         try {
-            $this->normalUserClient->enableUserMFA($userId, '12345');
+            $this->normalUserClient->disableUserMFA($userId);
             $this->fail("normal user should not be able to enable mfa via thea api");
         } catch(ClientException $e) {
             $this->assertEquals(403, $e->getCode());
         }
-        // enable mfa
-        $this->client->enableUserMFA($userId, '12345');
-        $user = $this->client->getUser($userId);
-        $this->assertTrue($user['mfaEnabled']);
 
         try {
-            $this->normalUserClient->disableUserMFA($userId);
-            $this->fail("normal user should not be able to disable mfa via thea api");
+            $this->client->disableUserMFA($userId);
+            $this->fail("you cannot disable mfa for user having mfa disabled");
         } catch(ClientException $e) {
-            $this->assertEquals(403, $e->getCode());
+            $this->assertEquals(400, $e->getCode());
         }
-        // disable mfa
-        $this->client->disableUserMFA($userId);
-        $user = $this->client->getUser($userId);
-        $this->assertFalse($user['mfaEnabled']);
     }
 }

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -128,17 +128,28 @@ class UsersTest extends ClientTestCase
         $this->assertFalse($user['mfaEnabled']);
 
         try {
-            $this->normalUserClient->disableUserMFA($userId);
-            $this->fail("normal user should not be able to enable mfa via thea api");
-        } catch(ClientException $e) {
-            $this->assertEquals(403, $e->getCode());
-        }
-
-        try {
             $this->client->disableUserMFA($userId);
             $this->fail("you cannot disable mfa for user having mfa disabled");
         } catch(ClientException $e) {
             $this->assertEquals(400, $e->getCode());
+        }
+    }
+
+    public function testNormalUserShouldNotBeAbleDisableMFA()
+    {
+        $token = $this->normalUserClient->verifyToken();
+        $userId = $token['user']['id'];
+
+        $user = $this->client->getUser($userId);
+
+        $this->assertArrayHasKey('mfaEnabled', $user);
+        $this->assertFalse($user['mfaEnabled']);
+
+        try {
+            $this->normalUserClient->disableUserMFA($userId);
+            $this->fail("normal user should not be able to enable mfa via thea api");
+        } catch(ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
         }
     }
 }

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -116,4 +116,37 @@ class UsersTest extends ClientTestCase
         $this->assertNotEquals($oldUserName, $updatedUser['name']);
         $this->assertEquals($newUserName, $updatedUser['name']);
     }
+
+    public function testDisableUserMFA()
+    {
+        $token = $this->normalUserClient->verifyToken();
+        $userId = $token['user']['id'];
+
+        $user = $this->client->getUser($userId);
+
+        $this->assertArrayHasKey($user, 'mfaEnabled');
+        $this->assertFalse($user['mfaEnabled']);
+
+        try {
+            $this->normalUserClient->enableUserMFA($userId, '12345');
+            $this->fail("normal user should not be able to enable mfa via thea api");
+        } catch(ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+        }
+        // enable mfa
+        $this->client->enableUserMFA($userId, '12345');
+        $user = $this->client->getUser($userId);
+        $this->assertTrue($user['mfaEnabled']);
+
+        try {
+            $this->normalUserClient->disableUserMFA($userId);
+            $this->fail("normal user should not be able to disable mfa via thea api");
+        } catch(ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+        }
+        // disable mfa
+        $this->client->disableUserMFA($userId);
+        $user = $this->client->getUser($userId);
+        $this->assertFalse($user['mfaEnabled']);
+    }
 }


### PR DESCRIPTION
Regarding: https://github.com/keboola/connection/issues/1109

Caution: this is just how it could work in my imagination.  It may be the case that this is the type of thing that can't be tested and that this kind of bypass is too risky.

Proposed changes:
- add endpoint `/manage/users/[user_id_or_email]/mfa` for `POST` with `secret` for enable and `DELETE` for disable

