### PR TITLE
snowflake backend is default, mysql removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,20 @@ require 'vendor/autoload.php';
 Read more in [Composer documentation](http://getcomposer.org/doc/01-basic-usage.md)
 
 ## Usage examples
-TODO
+
+
+```php
+require 'vendor/autoload.php';
+
+use Keboola\ManageApi\Client;
+
+$client = new Client([
+    'token' => getenv('MY_MANAGE_TOKEN'),
+    'url' => 'https://connnection.keboola.com',
+]);
+
+$project = $client->getProject(234);
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ TODO
 
 ## Tests
 
+
+The main purpose of these test is "black box" test driven development of Keboola Connection. These test guards the API implementation.
+You can run these tests only against non-production environments.
+
 Tests requires valid Keboola Management API tokens and an endpoint URL of the API test environment.
 
 *Note: The test environment should be running a cronjob for `token-expirator` otherwise the `testTemporaryAccess` test will fail.*
@@ -55,7 +59,7 @@ Create file `.env` with environment variables:
 KBC_MANAGE_API_URL=https://connection.keboola.com  
 KBC_MANAGE_API_TOKEN=your_token
 KBC_SUPER_API_TOKEN=your_token
-KBC_TEST_MAINTAINER_ID=1
+KBC_TEST_MAINTAINER_ID=2
 KBC_TEST_ADMIN_EMAIL=email_of_another_admin
 KBC_TEST_ADMIN_TOKEN=token_of_another_admin
 ```
@@ -71,7 +75,7 @@ Description of mentioned variables:
 - `KBC_MANAGE_API_URL` - URL where Keboola Connection is running
 - `KBC_MANAGE_API_TOKEN` - manage api token assigned to user **with** **superadmin** privileges. Can be created in Account Settings under the title Personal Access Tokens 
 - `KBC_SUPER_API_TOKEN` - can be created in manage-apps on the Tokens tab
-- `KBC_TEST_MAINTAINER_ID` - `id` of maintainer. This can be left as is, since you probably run tests for this maintainer.
+- `KBC_TEST_MAINTAINER_ID` - `id` of maintainer. Please create a new maintainer dedicated to test suite. All maintainer's organizations and projects all purged before tests!
 - `KBC_TEST_ADMIN_EMAIL` - email address of another user without any organizations
 - `KBC_TEST_ADMIN_TOKEN` - is also a Personal Access Token of user **without** **superadmin** privileges , but for a different user than that which has `KBC_MANAGE_API_TOKEN`
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class Client
 {
-    private $apiUrl = "https://connection.keboola.com";
+    private $apiUrl;
 
     private $tokenString = '';
 
@@ -46,9 +46,10 @@ class Client
         }
         $this->tokenString = $config['token'];
 
-        if (isset($config['url'])) {
-            $this->apiUrl = $config['url'];
+        if (!isset($config['url'])) {
+            throw new \InvalidArgumentException('url must be set');
         }
+        $this->apiUrl = $config['url'];
 
         if (isset($config['backoffMaxTries'])) {
             $this->backoffMaxTries = (int)$config['backoffMaxTries'];

--- a/tests/ClientTestCase.php
+++ b/tests/ClientTestCase.php
@@ -28,7 +28,23 @@ class ClientTestCase extends \PHPUnit_Framework_TestCase
     protected $normalUser;
 
     protected $superAdmin;
-    
+
+    public static function setUpBeforeClass()
+    {
+        $client = new Client([
+            'token' => getenv('KBC_MANAGE_API_TOKEN'),
+            'url' => getenv('KBC_MANAGE_API_URL'),
+            'backoffMaxTries' => 0,
+        ]);
+        $organizations = $client->listMaintainerOrganizations(getenv('KBC_TEST_MAINTAINER_ID'));
+        foreach ($organizations as $organization) {
+            foreach ($client->listOrganizationProjects($organization['id']) as $project) {
+                $client->deleteProject($project['id']);
+            }
+            $client->deleteOrganization($organization['id']);
+        }
+    }
+
     public function setUp()
     {
         $this->client = new Client([

--- a/tests/ClientTestCase.php
+++ b/tests/ClientTestCase.php
@@ -47,6 +47,7 @@ class ClientTestCase extends \PHPUnit_Framework_TestCase
             throw new \Exception('Tests cannot be executed against production host - ' . $manageApiUrl);
         }
 
+        // cleanup organizations and projects created in testing maintainer
         $client = new Client([
             'token' => getenv('KBC_MANAGE_API_TOKEN'),
             'url' => $manageApiUrl,

--- a/tests/MaintainersTest.php
+++ b/tests/MaintainersTest.php
@@ -19,7 +19,7 @@ class MaintainersTest extends ClientTestCase
         $testMaintainer = $this->client->getMaintainer($this->testMaintainerId);
 
         $newMaintainer = $this->client->createMaintainer([
-            'name' => "test maintainer",
+            'name' => self::TESTS_MAINTAINER_PREFIX . " - test maintainer",
             'defaultConnectionMysqlId' => $testMaintainer['defaultConnectionMysqlId'],
             'defaultConnectionRedshiftId' => $testMaintainer['defaultConnectionRedshiftId'],
             'defaultConnectionSnowflakeId' => $testMaintainer['defaultConnectionSnowflakeId'],
@@ -67,7 +67,7 @@ class MaintainersTest extends ClientTestCase
         }
 
         $newMaintainer = $this->client->createMaintainer([
-            'name' => "test maintainer"
+            'name' => self::TESTS_MAINTAINER_PREFIX . " - test maintainer"
         ]);
         $updateArray = ['name' => 'updated name'];
         if (!is_null($mysqlBackend)) {
@@ -113,7 +113,7 @@ class MaintainersTest extends ClientTestCase
         $testMaintainer = $this->client->getMaintainer($this->testMaintainerId);
         try {
             $newMaintainer = $this->normalUserClient->createMaintainer([
-                'name' => "test maintainer",
+                'name' => self::TESTS_MAINTAINER_PREFIX . " - test maintainer",
                 'defaultConnectionMysqlId' => $testMaintainer['defaultConnectionMysqlId'],
                 'defaultConnectionRedshiftId' => $testMaintainer['defaultConnectionRedshiftId'],
                 'defaultConnectionSnowflakeId' => $testMaintainer['defaultConnectionSnowflakeId'],
@@ -146,7 +146,9 @@ class MaintainersTest extends ClientTestCase
 
     public function testCrossMaintainerOrganizationAccess()
     {
-        $secondMaintainer = $this->client->createMaintainer(["name" => "secondary maintainer"]);
+        $secondMaintainer = $this->client->createMaintainer([
+            "name" => self::TESTS_MAINTAINER_PREFIX . " - secondary maintainer"
+        ]);
         $this->client->addUserToMaintainer($secondMaintainer['id'], ["id" => $this->normalUser['id']]);
         $this->client->removeUserFromMaintainer($secondMaintainer['id'], $this->superAdmin['id']);
 

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -51,7 +51,7 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('limits', $foundProject);
         $this->assertTrue(count($foundProject['limits']) > 1);
         $this->assertArrayHasKey('metrics', $foundProject);
-        $this->assertEquals('mysql', $foundProject['defaultBackend']);
+        $this->assertEquals('snowflake', $foundProject['defaultBackend']);
         $this->assertArrayHasKey('isDisabled', $foundProject);
         $this->assertEquals('production', $project['type']);
         $this->assertNull($project['expires']);
@@ -74,11 +74,11 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('backends', $project);
 
         $backends = $project['backends'];
-        $this->assertArrayHasKey('mysql', $backends);
+        $this->assertArrayHasKey('snowflake', $backends);
 
-        $mysql = $backends['mysql'];
-        $this->assertInternalType('int', $mysql['id']);
-        $this->assertArrayHasKey('host', $mysql);
+        $snowflakeBackend = $backends['snowflake'];
+        $this->assertInternalType('int', $snowflakeBackend['id']);
+        $this->assertArrayHasKey('host', $snowflakeBackend);
 
         return $foundProject;
     }
@@ -381,7 +381,7 @@ class ProjectsTest extends ClientTestCase
         // fetch again
         $project = $this->client->getProject($project['id']);
         $this->assertEquals($newName, $project['name']);
-        $this->assertEquals('mysql', $project['defaultBackend']);
+        $this->assertEquals('snowflake', $project['defaultBackend']);
 
         // update - change backend
         $project = $this->client->updateProject($project['id'], [

--- a/tests/StorageBackendTest.php
+++ b/tests/StorageBackendTest.php
@@ -39,11 +39,11 @@ class StorageBackendTest extends ClientTestCase
         ]);
 
         $this->assertArrayHasKey('backends', $project);
-        $this->assertEquals('mysql', $project['defaultBackend']);
+        $this->assertEquals('snowflake', $project['defaultBackend']);
 
         $backends = $project['backends'];
 
-        $this->assertArrayHasKey('mysql', $backends);
+        $this->assertArrayHasKey('snowflake', $backends);
         $this->assertArrayNotHasKey('redshift', $backends);
         
         
@@ -77,71 +77,6 @@ class StorageBackendTest extends ClientTestCase
         $sapiClient->dropBucket($bucketId);
 
         $this->client->removeProjectStorageBackend($project['id'], $redshiftBackend['id']);
-    }
-
-    public function testStorageAssignSnowflakeBackend()
-    {
-        // get redshift backend
-        $backends = $this->client->listStorageBackend();
-        $snowflakeBackend = null;
-        foreach ($backends as $backend) {
-            if ($backend['backend'] == 'snowflake') {
-                $snowflakeBackend = $backend;
-                break;
-            }
-        }
-        if (!$snowflakeBackend) {
-            $this->fail('Snowflake backend not found');
-        }
-
-        $name = 'My org';
-        $organization = $this->client->createOrganization($this->testMaintainerId, [
-            'name' => $name,
-        ]);
-
-        $project = $this->client->createProject($organization['id'], [
-            'name' => 'My test',
-        ]);
-
-        $this->assertArrayHasKey('backends', $project);
-        $this->assertEquals('mysql', $project['defaultBackend']);
-
-        $backends = $project['backends'];
-
-        $this->assertArrayHasKey('mysql', $backends);
-        $this->assertArrayNotHasKey('snowflake', $backends);
-
-
-        $this->client->assignProjectStorageBackend($project['id'], $snowflakeBackend['id']);
-
-        $project = $this->client->getProject($project['id']);
-        $backends = $project['backends'];
-
-        $this->assertArrayHasKey('snowflake', $backends);
-        $this->assertEquals('snowflake', $project['defaultBackend']);
-
-        $redshift = $backends['snowflake'];
-        $this->assertEquals($snowflakeBackend['id'], $redshift['id']);
-
-        // let's try to create a bucket in project now
-
-        $token = $this->client->createProjectStorageToken($project['id'], [
-            'description' => 'test',
-            'expiresIn' => 60,
-            'canManageBuckets' => true,
-        ]);
-
-        $sapiClient = new \Keboola\StorageApi\Client([
-            'url' => getenv('KBC_MANAGE_API_URL'),
-            'token' => $token['token'],
-        ]);
-        $bucketId = $sapiClient->createBucket('test', 'in');
-        $bucket = $sapiClient->getBucket($bucketId);
-        $this->assertEquals('snowflake', $bucket['backend']);
-
-        $sapiClient->dropBucket($bucketId);
-
-        $this->client->removeProjectStorageBackend($project['id'], $snowflakeBackend['id']);
     }
 
     public function testStorageBackendList()
@@ -185,7 +120,7 @@ class StorageBackendTest extends ClientTestCase
         ]);
 
         $this->assertArrayHasKey('backends', $project);
-        $this->assertEquals('mysql', $project['defaultBackend']);
+        $this->assertEquals('snowflake', $project['defaultBackend']);
         $this->assertCount(1, $project['backends']);
         
         $this->client->removeProjectStorageBackend($project['id'], reset($project['backends'])['id']);


### PR DESCRIPTION
- remove mysql backend
- separate maintainer for running tests
- organizations and projects cleanup on tests start in tests maintainer
- don't allow to run tests against production hosts
- URL parametr of client is required