### PR TITLE
Refactoring: external network 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   tests:
     build: .
@@ -20,3 +20,7 @@ services:
          composer install
          && ./vendor/bin/phpunit
          '
+networks:
+  default:
+    external:
+      name: connection_api-tests


### PR DESCRIPTION
Docker-compose.yml by měl mít taky externí síť, aby se dala používat adresa http://connection-apache