### PR TITLE
Maintainer invitations

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -218,6 +218,131 @@ A partial update of a maintainer
 
 + Response 204
 
+## Maintainer Invitations [/manage/maintainers/{maintainer_id}/invitations]
+
++ Parameters
+    + maintainer_id (required, int) - Maintainer ID
+
+### List invitations [GET]
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 200
+
+    ```js
+    [
+        {
+            "id": 112,
+            "created": "2018-07-10T10:45:11+0200",
+            "user": {
+                "id": 124,
+                "name": "test user 2",
+                "email": "spam@keboola.com"
+            },
+            "creator": {
+                "id": 123,
+                "name": "test user",
+                "email": "martin@keboola.com"
+            }
+        },
+        {
+            "id": 113,
+            "created": "2018-07-10T10:50:00+0200",
+            "user": {
+                "id": 125,
+                "name": "test user 3",
+                "email": "spam@keboola.com"
+            },
+            "creator": {
+                "id": 123,
+                "name": "test user",
+                "email": "martin@keboola.com"
+            }
+        }
+    ]
+    ```
+
+
+### Invite a user to a maintainer [POST]
+
+Only members of the maintainer and superadmins can invite other users.
+
++ Attributes
+
+    + email: martin@keboola.com (string, required) - Email of an invited user
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 201
+
+
+    ```js
+    {
+        "id": 113,
+        "created": "2018-07-10T10:50:00+0200",
+        "user": {
+            "id": 125,
+            "name": "test user 3",
+            "email": "spam@keboola.com"
+        },
+        "creator": {
+            "id": 123,
+            "name": "test user",
+            "email": "martin@keboola.com"
+        }
+    }
+    ```
+
+## Manage User Invitation [/manage/maintainers/{maintainer_id}/invitations/{invitation_id}]
+
++ Parameters
+    + maintainer_id (required, int) - Maintainer ID
+    + invitation_id (required, int) - User ID
+
+
+### Invitation detail [GET]
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 200
+
+
+    ```js
+    {
+        "id": 113,
+        "created": "2018-07-10T10:50:00+0200",
+        "user": {
+            "id": 125,
+            "name": "test user 3",
+            "email": "spam@keboola.com"
+        },
+        "creator": {
+            "id": 123,
+            "name": "test user",
+            "email": "martin@keboola.com"
+        }
+    }
+
+### Cancel a invitation [DELETE]
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 204
+
+
+
 ## Maintainer Users [/manage/maintainers/{maintainer_id}/users]
 
 + Parameters
@@ -1792,6 +1917,81 @@ all notifications as read.
 
 
 # Group My Account
+
+## Maintainers Invitations [/manage/current-user/maintainers-invitations]
+
+### List invitations [GET]
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 200 (application/json)
+
+    ```js
+    [
+        {
+            "id": 113,
+            "created": "2018-07-10T11:13:00+0200",
+            "maintainer": {
+                "id": 7,
+                "name": "Keboola CZ"
+            },
+            "creator": {
+                "id": 2,
+                "name": "Martin Halamicek",
+                "email": "martin@keboola.com"
+            }
+        }
+    ]
+    ```
+
+## Manage Maintainer Invitation [/manage/current-user/maintainers-invitations/{invitation_id}]
+
+### Invitation detail [GET]
+
++ Parameters
+    + invitation_id (number, required) - Invitation ID
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 200 (application/json)
+
+    ```js
+    {
+        "id": 113,
+        "created": "2018-07-10T11:13:00+0200",
+        "maintainer": {
+            "id": 7,
+            "name": "Keboola CZ"
+        },
+        "creator": {
+            "id": 2,
+            "name": "Martin Halamicek",
+            "email": "martin@keboola.com"
+        }
+    }
+    ```
+
+### Accept a invitation [PUT]
+
+Invitation will be accepted and current user will become a member of the maintainer.
+
++ Parameters
+    + invitation_id (number, required) - Invitation ID
+
++ Request (application/json)
+    + Headers
+
+            X-KBC-ManageApiToken: your_token
+
++ Response 202
+
+
 
 ## Organizations Invitations [/manage/current-user/organizations-invitations]
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -148,6 +148,51 @@ class Client
         $this->apiDelete("/manage/users/{$userId}");
     }
 
+    public function inviteUserToMaintainer($maintainerId, $params = [])
+    {
+        return $this->apiPost("manage/maintainers/{$maintainerId}/invitations", $params);
+    }
+
+    public function listMaintainerInvitations($id)
+    {
+        return $this->apiGet("/manage/maintainers/{$id}/invitations");
+    }
+
+    public function getMaintainerInvitation($maintainerId, $invitationId)
+    {
+        return $this->apiGet("/manage/maintainers/{$maintainerId}/invitations/{$invitationId}");
+    }
+
+    public function cancelMaintainerInvitation($maintainerId, $invitationId)
+    {
+        $this->apiDelete("/manage/maintainers/{$maintainerId}/invitations/{$invitationId}");
+    }
+
+    public function listMyMaintainerInvitations()
+    {
+        return $this->apiGet("/manage/current-user/maintainers-invitations");
+    }
+
+    public function acceptMyMaintainerInvitation($id)
+    {
+        $this->apiPut("/manage/current-user/maintainers-invitations/{$id}", []);
+    }
+
+    public function getMyMaintainerInvitation($id)
+    {
+        return $this->apiGet("/manage/current-user/maintainers-invitations/{$id}");
+    }
+
+    public function declineMyMaintainerInvitation($id)
+    {
+        $this->apiDelete("/manage/current-user/maintainers-invitations/{$id}");
+    }
+
+    public function joinMaintainer($maintainerId)
+    {
+        $this->apiPost("/manage/maintainers/{$maintainerId}/join-maintainer");
+    }
+
     public function listMaintainerOrganizations($maintainerId)
     {
         return $this->apiGet("/manage/maintainers/{$maintainerId}/organizations");

--- a/tests/ClientTestCase.php
+++ b/tests/ClientTestCase.php
@@ -99,4 +99,43 @@ class ClientTestCase extends \PHPUnit_Framework_TestCase
     {
         return uniqid('', true);
     }
+
+    protected function findMaintainerMember(int $maintainerId, string $userEmail): ?array
+    {
+        $members = $this->client->listMaintainerMembers($maintainerId);
+
+        foreach ($members as $member) {
+            if ($member['email'] === $userEmail) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+
+    protected function findOrganizationMember(int $organizationId, string $userEmail): ?array
+    {
+        $members = $this->client->listOrganizationUsers($organizationId);
+
+        foreach ($members as $member) {
+            if ($member['email'] === $userEmail) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+
+    protected function findProjectUser(int $projectId, string $userEmail): ?array
+    {
+        $projectUsers = $this->client->listProjectUsers($projectId);
+
+        foreach ($projectUsers as $projectUser) {
+            if ($projectUser['email'] === $userEmail) {
+                return $projectUser;
+            }
+        }
+
+        return null;
+    }
 }

--- a/tests/ClientTestCase.php
+++ b/tests/ClientTestCase.php
@@ -74,18 +74,26 @@ class ClientTestCase extends \PHPUnit_Framework_TestCase
             'url' => getenv('KBC_MANAGE_API_URL'),
             'backoffMaxTries' => 0,
         ]);
-        $this->testMaintainerId = getenv('KBC_TEST_MAINTAINER_ID');
+        $this->testMaintainerId = (int) getenv('KBC_TEST_MAINTAINER_ID');
 
         $this->normalUser = $this->normalUserClient->verifyToken()['user'];
         $this->superAdmin = $this->client->verifyToken()['user'];
 
         // cleanup maintainers created by tests
         $maintainers = $this->client->listMaintainers();
+
         foreach ($maintainers as $maintainer) {
-            if ((int) $maintainer['id'] === (int) $this->testMaintainerId) {
+            if ($maintainer['id'] === $this->testMaintainerId) {
+                if (!$this->findMaintainerMember($this->testMaintainerId, $this->superAdmin['email'])) {
+                    $this->client->addUserToMaintainer(
+                        $this->testMaintainerId,
+                        ['email' => $this->superAdmin['email']]
+                    );
+                }
+
                 $members = $this->client->listMaintainerMembers($maintainer['id']);
                 foreach ($members as $member) {
-                    if ($member['id'] != $this->superAdmin['id']) {
+                    if ($member['id'] !== $this->superAdmin['id']) {
                         $this->client->removeUserFromMaintainer($maintainer['id'], $member['id']);
                     }
                 }

--- a/tests/MaintainerInvitationsTest.php
+++ b/tests/MaintainerInvitationsTest.php
@@ -1,0 +1,345 @@
+<?php
+namespace Keboola\ManageApiTest;
+
+use Keboola\ManageApi\ClientException;
+
+class MaintainerInvitationsTest extends ClientTestCase
+{
+    private $maintainer;
+
+    /**
+     * Create empty maintainer without admins and decline all maintainer invitations for test users
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->maintainer = $this->client->createMaintainer([
+            'name' => self::TESTS_MAINTAINER_PREFIX . " - MaintainerJoinTest",
+        ]);
+
+        $this->client->removeUserFromMaintainer($this->maintainer['id'], $this->superAdmin['id']);
+
+        foreach ($this->normalUserClient->listMyMaintainerInvitations() as $invitation) {
+            $this->normalUserClient->declineMyMaintainerInvitation($invitation['id']);
+        }
+
+        foreach ($this->client->listMyMaintainerInvitations() as $invitation) {
+            $this->client->declineMyMaintainerInvitation($invitation['id']);
+        }
+    }
+
+    public function testSuperAdminCanInvite(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNull($member);
+
+        $invitation = $this->client->inviteUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $this->assertEquals($this->normalUser['id'], $invitation['user']['id']);
+        $this->assertEquals($this->normalUser['email'], $invitation['user']['email']);
+        $this->assertEquals($this->normalUser['name'], $invitation['user']['name']);
+
+        $this->assertEquals($this->superAdmin['id'], $invitation['creator']['id']);
+        $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
+        $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+
+        $this->assertEquals($invitation, reset($invitations));
+
+        $this->assertEquals($invitation, $this->client->getMaintainerInvitation($maintainerId, $invitation['id']));
+
+        $this->client->cancelMaintainerInvitation($maintainerId, $invitation['id']);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNull($member);
+    }
+
+    public function testMaintainerAdminCanInvite(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNull($member);
+
+        $invitation= $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+
+        $this->assertEquals($this->superAdmin['id'], $invitation['user']['id']);
+        $this->assertEquals($this->superAdmin['email'], $invitation['user']['email']);
+        $this->assertEquals($this->superAdmin['name'], $invitation['user']['name']);
+
+        $this->assertEquals($this->normalUser['id'], $invitation['creator']['id']);
+        $this->assertEquals($this->normalUser['email'], $invitation['creator']['email']);
+        $this->assertEquals($this->normalUser['name'], $invitation['creator']['name']);
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+
+        $this->assertEquals($invitation, reset($invitations));
+
+        $this->assertEquals($invitation, $this->normalUserClient->getMaintainerInvitation($maintainerId, $invitation['id']));
+
+        $this->normalUserClient->cancelMaintainerInvitation($maintainerId, $invitation['id']);
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNull($member);
+    }
+
+    public function testRandomAdminCannotInvite(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNull($member);
+
+        try {
+            $this->normalUserClient->listMaintainerInvitations($maintainerId);
+            $this->fail('List invitations should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+        }
+
+        try {
+            $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+            $this->fail('Invite someone should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+        }
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNull($member);
+    }
+
+    public function testAdminAcceptsInvitation(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $this->client->inviteUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $invitations = $this->normalUserClient->listMyMaintainerInvitations();
+        $this->assertCount(1, $invitations);
+
+        $invitation = reset($invitations);
+
+        $this->assertEquals($maintainerId, $invitation['maintainer']['id']);
+        $this->assertEquals($this->maintainer['name'], $invitation['maintainer']['name']);
+
+        $this->assertEquals($this->superAdmin['id'], $invitation['creator']['id']);
+        $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
+        $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
+
+        $this->assertEquals($invitation, $this->normalUserClient->getMyMaintainerInvitation($invitation['id']));
+
+        $this->normalUserClient->acceptMyMaintainerInvitation($invitation['id']);
+
+        $invitations = $this->normalUserClient->listMyMaintainerInvitations();
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNotNull($member);
+
+        $this->assertArrayHasKey('invitor', $member);
+
+        $this->assertNotEmpty($member['invitor']);
+        $this->assertNotEmpty($member['created']);
+        $this->assertEquals($this->superAdmin['id'], $member['invitor']['id']);
+        $this->assertEquals($this->superAdmin['email'], $member['invitor']['email']);
+        $this->assertEquals($this->superAdmin['name'], $member['invitor']['name']);
+    }
+
+    public function testAdminDeclinesInvitation(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $this->client->inviteUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $invitations = $this->normalUserClient->listMyMaintainerInvitations();
+        $this->assertCount(1, $invitations);
+
+        $invitation = reset($invitations);
+
+        $this->assertEquals($maintainerId, $invitation['maintainer']['id']);
+        $this->assertEquals($this->maintainer['name'], $invitation['maintainer']['name']);
+
+        $this->assertEquals($this->superAdmin['id'], $invitation['creator']['id']);
+        $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
+        $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
+
+        $this->normalUserClient->declineMyMaintainerInvitation($invitation['id']);
+
+        $invitations = $this->normalUserClient->listMyMaintainerInvitations();
+        $this->assertCount(0, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNull($member);
+    }
+
+    public function testCannotInviteAlreadyInvitedUser(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+
+        // send invitation twice
+        try {
+            $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+            $this->fail('Invite user to maintainer twice should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(400, $e->getCode());
+            $this->assertContains('already', $e->getMessage());
+            $this->assertContains('invited', $e->getMessage());
+        }
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+    }
+
+    public function testCannotInviteExistingMember(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $this->normalUserClient->addUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+
+        try {
+            $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+            $this->fail('Invite existing member to maintainer should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(400, $e->getCode());
+            $this->assertContains('already', $e->getMessage());
+            $this->assertContains('member', $e->getMessage());
+        }
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+    }
+
+    public function testRandomAdminCannotManageInvitationsInMaintainer(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $invitation = $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+
+        $this->assertEquals($invitation, reset($invitations));
+
+        $this->normalUserClient->removeUserFromMaintainer($maintainerId, $this->normalUser['id']);
+
+        try {
+            $this->normalUserClient->cancelMaintainerInvitation($maintainerId, $invitation['id']);
+            $this->fail('Cancel invitations should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+        }
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+    }
+
+    public function testDeletingMaintainerRemovesInvitations(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+
+        $invitations = $this->client->listMyMaintainerInvitations();
+        $this->assertCount(1, $invitations);
+
+        $this->client->deleteMaintainer($maintainerId);
+
+        $invitations = $this->client->listMyMaintainerInvitations();
+        $this->assertCount(0, $invitations);
+    }
+
+    public function testAddingAdminToMaintainerDeletesCorrespondingInvitation(): void
+    {
+        $inviteeEmail = $this->normalUser['email'];
+        $secondInviteeEmail = 'spam@keboola.com';
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->joinMaintainer($maintainerId);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(0, $invitations);
+
+        $this->client->inviteUserToMaintainer($maintainerId, ['email' => $inviteeEmail]);
+        $this->client->inviteUserToMaintainer($maintainerId, ['email' => $secondInviteeEmail]);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(2, $invitations);
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $inviteeEmail]);
+
+        $member = $this->findMaintainerMember($maintainerId, $inviteeEmail);
+        $this->assertNotNull($member);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+
+        $invitation = reset($invitations);
+
+        $this->assertEquals($secondInviteeEmail, $invitation['user']['email']);
+
+        $this->assertEquals($this->superAdmin['id'], $invitation['creator']['id']);
+        $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
+        $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
+    }
+
+    private function findMaintainerMember(int $maintainerId, string $userEmail): ?array
+    {
+        $members = $this->client->listMaintainerMembers($maintainerId);
+
+        foreach ($members as $member) {
+            if ($member['email'] === $userEmail) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/MaintainerInvitationsTest.php
+++ b/tests/MaintainerInvitationsTest.php
@@ -329,17 +329,4 @@ class MaintainerInvitationsTest extends ClientTestCase
         $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
         $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
     }
-
-    private function findMaintainerMember(int $maintainerId, string $userEmail): ?array
-    {
-        $members = $this->client->listMaintainerMembers($maintainerId);
-
-        foreach ($members as $member) {
-            if ($member['email'] === $userEmail) {
-                return $member;
-            }
-        }
-
-        return null;
-    }
 }

--- a/tests/MaintainerInvitationsTest.php
+++ b/tests/MaintainerInvitationsTest.php
@@ -18,6 +18,7 @@ class MaintainerInvitationsTest extends ClientTestCase
             'name' => self::TESTS_MAINTAINER_PREFIX . " - MaintainerJoinTest",
         ]);
 
+        $this->client->addUserToMaintainer($this->maintainer['id'], ['email' => 'spam+spam@keboola.com']);
         $this->client->removeUserFromMaintainer($this->maintainer['id'], $this->superAdmin['id']);
 
         foreach ($this->normalUserClient->listMyMaintainerInvitations() as $invitation) {

--- a/tests/MaintainerInvitationsTest.php
+++ b/tests/MaintainerInvitationsTest.php
@@ -15,7 +15,7 @@ class MaintainerInvitationsTest extends ClientTestCase
         parent::setUp();
 
         $this->maintainer = $this->client->createMaintainer([
-            'name' => self::TESTS_MAINTAINER_PREFIX . " - MaintainerJoinTest",
+            'name' => self::TESTS_MAINTAINER_PREFIX . " - MaintainerInvitationsTest",
         ]);
 
         $this->client->addUserToMaintainer($this->maintainer['id'], ['email' => 'spam+spam@keboola.com']);
@@ -78,7 +78,7 @@ class MaintainerInvitationsTest extends ClientTestCase
         $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
         $this->assertNull($member);
 
-        $invitation= $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+        $invitation = $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
 
         $this->assertEquals($this->superAdmin['id'], $invitation['user']['id']);
         $this->assertEquals($this->superAdmin['email'], $invitation['user']['email']);
@@ -150,11 +150,6 @@ class MaintainerInvitationsTest extends ClientTestCase
         $invitation = reset($invitations);
 
         $this->assertEquals($maintainerId, $invitation['maintainer']['id']);
-        $this->assertEquals($this->maintainer['name'], $invitation['maintainer']['name']);
-
-        $this->assertEquals($this->superAdmin['id'], $invitation['creator']['id']);
-        $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
-        $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
 
         $this->assertEquals($invitation, $this->normalUserClient->getMyMaintainerInvitation($invitation['id']));
 
@@ -190,11 +185,6 @@ class MaintainerInvitationsTest extends ClientTestCase
         $invitation = reset($invitations);
 
         $this->assertEquals($maintainerId, $invitation['maintainer']['id']);
-        $this->assertEquals($this->maintainer['name'], $invitation['maintainer']['name']);
-
-        $this->assertEquals($this->superAdmin['id'], $invitation['creator']['id']);
-        $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
-        $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
 
         $this->normalUserClient->declineMyMaintainerInvitation($invitation['id']);
 

--- a/tests/MaintainerJoinTest.php
+++ b/tests/MaintainerJoinTest.php
@@ -18,6 +18,7 @@ class MaintainerJoinTest extends ClientTestCase
             'name' => self::TESTS_MAINTAINER_PREFIX . " - MaintainerJoinTest",
         ]);
 
+        $this->client->addUserToMaintainer($this->maintainer['id'], ['email' => 'spam+spam@keboola.com']);
         $this->client->removeUserFromMaintainer($this->maintainer['id'], $this->superAdmin['id']);
     }
 

--- a/tests/MaintainerJoinTest.php
+++ b/tests/MaintainerJoinTest.php
@@ -1,0 +1,130 @@
+<?php
+namespace Keboola\ManageApiTest;
+
+use Keboola\ManageApi\ClientException;
+
+class MaintainerJoinTest extends ClientTestCase
+{
+    private $maintainer;
+
+    /**
+     * Create empty maintainer without admins, remove admins from test maintainer
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->maintainer = $this->client->createMaintainer([
+            'name' => self::TESTS_MAINTAINER_PREFIX . " - MaintainerJoinTest",
+        ]);
+
+        $this->client->removeUserFromMaintainer($this->maintainer['id'], $this->superAdmin['id']);
+    }
+
+    public function testSuperAdminCanJoinMaintainer(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNull($member);
+
+        $this->client->joinMaintainer($maintainerId);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNotNull($member);
+
+        $this->assertArrayHasKey('invitor', $member);
+        $this->assertEmpty($member['invitor']);
+    }
+
+    public function testSuperAdminAdminJoiningMaintainerDeletesCorrespondingInvitation(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+        $secondInviteeEmail = 'spam@keboola.com';
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $invitations = $this->client->listMyMaintainerInvitations();
+        $this->assertCount(0, $invitations);
+
+        $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $this->superAdmin['email']]);
+        $this->normalUserClient->inviteUserToMaintainer($maintainerId, ['email' => $secondInviteeEmail]);
+
+        $invitations = $this->client->listMyMaintainerInvitations();
+        $this->assertCount(1, $invitations);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNull($member);
+
+        $this->client->joinMaintainer($maintainerId);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->superAdmin['email']);
+        $this->assertNotNull($member);
+
+        $invitations = $this->client->listMyMaintainerInvitations();
+        $this->assertCount(0, $invitations);
+
+        $invitations = $this->client->listMaintainerInvitations($maintainerId);
+        $this->assertCount(1, $invitations);
+
+        $invitation = reset($invitations);
+
+        $this->assertEquals($secondInviteeEmail, $invitation['user']['email']);
+
+        $this->assertEquals($this->normalUser['id'], $invitation['creator']['id']);
+        $this->assertEquals($this->normalUser['email'], $invitation['creator']['email']);
+        $this->assertEquals($this->normalUser['name'], $invitation['creator']['name']);
+
+    }
+
+    public function testRandomAdminCannotJoinMaintainer(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNull($member);
+
+        try {
+            $this->normalUserClient->joinMaintainer($maintainerId);
+            $this->fail('Maintainer join should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(403, $e->getCode());
+        }
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNull($member);
+    }
+
+    public function testMaintainerMemberCannotJoinMaintainerAgain(): void
+    {
+        $maintainerId = $this->maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNotNull($member);
+
+        try {
+            $this->normalUserClient->joinMaintainer($maintainerId);
+            $this->fail('Maintainer join should produce error');
+        } catch (ClientException $e) {
+            $this->assertEquals(400, $e->getCode());
+        }
+
+        $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
+        $this->assertNotNull($member);
+    }
+
+    private function findMaintainerMember(int $maintainerId, string $userEmail): ?array
+    {
+        $members = $this->client->listMaintainerMembers($maintainerId);
+
+        foreach ($members as $member) {
+            if ($member['email'] === $userEmail) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/MaintainerJoinTest.php
+++ b/tests/MaintainerJoinTest.php
@@ -109,6 +109,7 @@ class MaintainerJoinTest extends ClientTestCase
             $this->normalUserClient->joinMaintainer($maintainerId);
             $this->fail('Maintainer join should produce error');
         } catch (ClientException $e) {
+            $this->assertContains('already a member', $e->getMessage());
             $this->assertEquals(400, $e->getCode());
         }
 

--- a/tests/MaintainerJoinTest.php
+++ b/tests/MaintainerJoinTest.php
@@ -114,17 +114,4 @@ class MaintainerJoinTest extends ClientTestCase
         $member = $this->findMaintainerMember($maintainerId, $this->normalUser['email']);
         $this->assertNotNull($member);
     }
-
-    private function findMaintainerMember(int $maintainerId, string $userEmail): ?array
-    {
-        $members = $this->client->listMaintainerMembers($maintainerId);
-
-        foreach ($members as $member) {
-            if ($member['email'] === $userEmail) {
-                return $member;
-            }
-        }
-
-        return null;
-    }
 }

--- a/tests/MaintainersTest.php
+++ b/tests/MaintainersTest.php
@@ -209,7 +209,37 @@ class MaintainersTest extends ClientTestCase
         $this->assertArrayHasKey('zendeskUrl', $maintainer);
         $this->assertNull($maintainer['zendeskUrl']);
     }
-    
+
+    public function testLeastOneMemberLimit()
+    {
+        $maintainer = $this->client->createMaintainer([
+            'name' => self::TESTS_MAINTAINER_PREFIX . " - test least one member"
+        ]);
+
+        $maintainerId = $maintainer['id'];
+
+        $this->client->addUserToMaintainer($maintainerId, ['email' => $this->normalUser['email']]);
+
+        $members = $this->client->listMaintainerMembers($maintainerId);
+        $this->assertCount(2, $members);
+
+        $this->client->removeUserFromMaintainer($maintainerId, $this->superAdmin['id']);
+
+        $members = $this->client->listMaintainerMembers($maintainerId);
+        $this->assertCount(1, $members);
+
+        try {
+            $this->client->removeUserFromMaintainer($maintainerId, $this->normalUser['id']);
+            $this->fail('The last member could not be removed from the maintainer');
+        } catch (ClientException $e) {
+            $this->assertEquals(400, $e->getCode());
+            $this->assertContains('least 1 member', $e->getMessage());
+        }
+
+        $members = $this->client->listMaintainerMembers($maintainerId);
+        $this->assertCount(1, $members);
+    }
+
     public function testUserMaintainerUsers()
     {
         $maintainerMembers = $this->client->listMaintainerMembers($this->testMaintainerId);

--- a/tests/MaintainersTest.php
+++ b/tests/MaintainersTest.php
@@ -212,25 +212,20 @@ class MaintainersTest extends ClientTestCase
     
     public function testUserMaintainerUsers()
     {
-        $maintainers = $this->client->listMaintainers();
-
-        $this->assertGreaterThan(0, count($maintainers));
-
-        $superAdmin = $this->client->verifyToken()['user'];
-        $maintainer = $maintainers[0];
-
-        $maintainerMembers = $this->client->listMaintainerMembers($maintainer['id']);
+        $maintainerMembers = $this->client->listMaintainerMembers($this->testMaintainerId);
         $this->assertCount(1,$maintainerMembers);
 
-        $this->client->addUserToMaintainer($maintainer['id'],['email' => $this->normalUser['email']]);
-        $maintainerMembers = $this->client->listMaintainerMembers($maintainer['id']);
+        $this->client->addUserToMaintainer($this->testMaintainerId,['email' => $this->normalUser['email']]);
+
+        $maintainerMembers = $this->client->listMaintainerMembers($this->testMaintainerId);
         $this->assertCount(2,$maintainerMembers);
 
-        $this->client->removeUserFromMaintainer($maintainer['id'], $this->normalUser['id']);
-        $maintainerMembers = $this->client->listMaintainerMembers($maintainer['id']);
-        $this->assertCount(1,$maintainerMembers);
-        $this->assertEquals($superAdmin['email'], $maintainerMembers[0]['email']);
+        $this->client->removeUserFromMaintainer($this->testMaintainerId, $this->normalUser['id']);
 
+        $maintainerMembers = $this->client->listMaintainerMembers($this->testMaintainerId);
+        $this->assertCount(1,$maintainerMembers);
+
+        $this->assertEquals($this->superAdmin['email'], $maintainerMembers[0]['email']);
     }
 
     // the remaining tests are testing maintainer user privileges

--- a/tests/MaintainersTest.php
+++ b/tests/MaintainersTest.php
@@ -210,7 +210,7 @@ class MaintainersTest extends ClientTestCase
         $this->assertNull($maintainer['zendeskUrl']);
     }
 
-    public function testLeastOneMemberLimit()
+    public function testAtLeastOneMemberLimit()
     {
         $maintainer = $this->client->createMaintainer([
             'name' => self::TESTS_MAINTAINER_PREFIX . " - test least one member"

--- a/tests/OrganizationInvitationsTest.php
+++ b/tests/OrganizationInvitationsTest.php
@@ -14,12 +14,7 @@ class OrganizationInvitationsTest extends ClientTestCase
     {
         parent::setUp();
 
-        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
-            'name' => 'My org',
-        ]);
-
-        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam+spam@keboola.com']);
-        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
+        $this->client->addUserToMaintainer($this->testMaintainerId, ['email' => 'spam+spam@keboola.com']);
 
         foreach ($this->client->listMaintainerMembers($this->testMaintainerId) as $member) {
             if ($member['id'] === $this->normalUser['id']) {
@@ -30,6 +25,13 @@ class OrganizationInvitationsTest extends ClientTestCase
                 $this->client->removeUserFromMaintainer($this->testMaintainerId, $member['id']);
             }
         }
+
+        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
+            'name' => 'My org',
+        ]);
+
+        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam+spam@keboola.com']);
+        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
 
         foreach ($this->normalUserClient->listMyOrganizationInvitations() as $invitation) {
             $this->normalUserClient->declineMyOrganizationInvitation($invitation['id']);

--- a/tests/OrganizationInvitationsTest.php
+++ b/tests/OrganizationInvitationsTest.php
@@ -415,17 +415,4 @@ class OrganizationInvitationsTest extends ClientTestCase
         $this->assertEquals($this->superAdmin['email'], $invitation['creator']['email']);
         $this->assertEquals($this->superAdmin['name'], $invitation['creator']['name']);
     }
-
-    private function findOrganizationMember(int $organizationId, string $userEmail): ?array
-    {
-        $members = $this->client->listOrganizationUsers($organizationId);
-
-        foreach ($members as $member) {
-            if ($member['email'] === $userEmail) {
-                return $member;
-            }
-        }
-
-        return null;
-    }
 }

--- a/tests/OrganizationJoinTest.php
+++ b/tests/OrganizationJoinTest.php
@@ -224,17 +224,4 @@ class OrganizationJoinTest extends ClientTestCase
             $this->assertEquals(400, $e->getCode());
         }
     }
-
-    private function findOrganizationMember(int $organizationId, string $userEmail): ?array
-    {
-        $members = $this->client->listOrganizationUsers($organizationId);
-
-        foreach ($members as $member) {
-            if ($member['email'] === $userEmail) {
-                return $member;
-            }
-        }
-
-        return null;
-    }
 }

--- a/tests/OrganizationJoinTest.php
+++ b/tests/OrganizationJoinTest.php
@@ -14,12 +14,7 @@ class OrganizationJoinTest extends ClientTestCase
     {
         parent::setUp();
 
-        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
-            'name' => 'My org',
-        ]);
-
-        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
-        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
+        $this->client->addUserToMaintainer($this->testMaintainerId, ['email' => 'spam+spam@keboola.com']);
 
         foreach ($this->client->listMaintainerMembers($this->testMaintainerId) as $member) {
             if ($member['id'] === $this->normalUser['id']) {
@@ -30,6 +25,13 @@ class OrganizationJoinTest extends ClientTestCase
                 $this->client->removeUserFromMaintainer($this->testMaintainerId, $member['id']);
             }
         }
+
+        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
+            'name' => 'My org',
+        ]);
+
+        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
+        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
     }
 
     public function testSuperAdminCanJoinOrganization(): void

--- a/tests/OrganizationsTest.php
+++ b/tests/OrganizationsTest.php
@@ -383,17 +383,4 @@ class OrganizationsTest extends ClientTestCase
             }
         }
     }
-
-    private function findProjectUser(int $projectId, string $userEmail): ?array
-    {
-        $projectUsers = $this->client->listProjectUsers($projectId);
-
-        foreach ($projectUsers as $projectUser) {
-            if ($projectUser['email'] === $userEmail) {
-                return $projectUser;
-            }
-        }
-
-        return null;
-    }
 }

--- a/tests/ProjectInvitationsTest.php
+++ b/tests/ProjectInvitationsTest.php
@@ -14,12 +14,7 @@ class ProjectInvitationsTest extends ClientTestCase
     {
         parent::setUp();
 
-        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
-            'name' => 'My org',
-        ]);
-
-        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
-        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
+        $this->client->addUserToMaintainer($this->testMaintainerId, ['email' => 'spam+spam@keboola.com']);
 
         foreach ($this->client->listMaintainerMembers($this->testMaintainerId) as $member) {
             if ($member['id'] === $this->normalUser['id']) {
@@ -30,6 +25,13 @@ class ProjectInvitationsTest extends ClientTestCase
                 $this->client->removeUserFromMaintainer($this->testMaintainerId, $member['id']);
             }
         }
+
+        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
+            'name' => 'My org',
+        ]);
+
+        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
+        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
 
         foreach ($this->normalUserClient->listMyProjectInvitations() as $invitation) {
             $this->normalUserClient->declineMyProjectInvitation($invitation['id']);

--- a/tests/ProjectInvitationsTest.php
+++ b/tests/ProjectInvitationsTest.php
@@ -571,19 +571,6 @@ class ProjectInvitationsTest extends ClientTestCase
         $this->assertCount(0, $invitations);
     }
 
-    private function findProjectUser(int $projectId, string $userEmail): ?array
-    {
-        $projectUsers = $this->client->listProjectUsers($projectId);
-
-        foreach ($projectUsers as $projectUser) {
-            if ($projectUser['email'] === $userEmail) {
-                return $projectUser;
-            }
-        }
-
-        return null;
-    }
-
     private function createProjectWithNormalAdminMember(): int
     {
         $project = $this->normalUserClient->createProject($this->organization['id'], [

--- a/tests/ProjectJoinRequestsTest.php
+++ b/tests/ProjectJoinRequestsTest.php
@@ -14,12 +14,7 @@ class ProjectJoinRequestsTest extends ClientTestCase
     {
         parent::setUp();
 
-        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
-            'name' => 'My org',
-        ]);
-
-        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
-        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
+        $this->client->addUserToMaintainer($this->testMaintainerId, ['email' => 'spam+spam@keboola.com']);
 
         foreach ($this->client->listMaintainerMembers($this->testMaintainerId) as $member) {
             if ($member['id'] === $this->normalUser['id']) {
@@ -30,6 +25,13 @@ class ProjectJoinRequestsTest extends ClientTestCase
                 $this->client->removeUserFromMaintainer($this->testMaintainerId, $member['id']);
             }
         }
+
+        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
+            'name' => 'My org',
+        ]);
+
+        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
+        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
 
         foreach ($this->normalUserClient->listMyProjectJoinRequests() as $joinRequest) {
             $this->normalUserClient->deleteMyProjectJoinRequest($joinRequest['id']);

--- a/tests/ProjectJoinRequestsTest.php
+++ b/tests/ProjectJoinRequestsTest.php
@@ -615,19 +615,6 @@ class ProjectJoinRequestsTest extends ClientTestCase
         $this->assertCount(0, $joinRequests);
     }
 
-    private function findProjectUser(int $projectId, string $userEmail): ?array
-    {
-        $projectUsers = $this->client->listProjectUsers($projectId);
-
-        foreach ($projectUsers as $projectUser) {
-            if ($projectUser['email'] === $userEmail) {
-                return $projectUser;
-            }
-        }
-
-        return null;
-    }
-
     private function createProjectWithNormalAdminMember(): int
     {
         $project = $this->normalUserClient->createProject($this->organization['id'], [

--- a/tests/ProjectJoinTest.php
+++ b/tests/ProjectJoinTest.php
@@ -14,12 +14,7 @@ class ProjectJoinTest extends ClientTestCase
     {
         parent::setUp();
 
-        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
-            'name' => 'My org',
-        ]);
-
-        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
-        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
+        $this->client->addUserToMaintainer($this->testMaintainerId, ['email' => 'spam+spam@keboola.com']);
 
         foreach ($this->client->listMaintainerMembers($this->testMaintainerId) as $member) {
             if ($member['id'] === $this->normalUser['id']) {
@@ -30,6 +25,13 @@ class ProjectJoinTest extends ClientTestCase
                 $this->client->removeUserFromMaintainer($this->testMaintainerId, $member['id']);
             }
         }
+
+        $this->organization = $this->client->createOrganization($this->testMaintainerId, [
+            'name' => 'My org',
+        ]);
+
+        $this->client->addUserToOrganization($this->organization['id'], ['email' => 'spam@keboola.com']);
+        $this->client->removeUserFromOrganization($this->organization['id'], $this->superAdmin['id']);
 
         foreach ($this->normalUserClient->listMyProjectJoinRequests() as $joinRequest) {
             $this->normalUserClient->deleteMyProjectJoinRequest($joinRequest['id']);

--- a/tests/ProjectJoinTest.php
+++ b/tests/ProjectJoinTest.php
@@ -396,19 +396,6 @@ class ProjectJoinTest extends ClientTestCase
         $this->assertNull($projectUser);
     }
 
-    private function findProjectUser(int $projectId, string $userEmail): ?array
-    {
-        $projectUsers = $this->client->listProjectUsers($projectId);
-
-        foreach ($projectUsers as $projectUser) {
-            if ($projectUser['email'] === $userEmail) {
-                return $projectUser;
-            }
-        }
-
-        return null;
-    }
-
     private function createProjectWithNormalAdminMember(): int
     {
         $project = $this->normalUserClient->createProject($this->organization['id'], [

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -1343,5 +1343,4 @@ class ProjectsTest extends ClientTestCase
 
         return null;
     }
-
 }

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -1317,30 +1317,4 @@ class ProjectsTest extends ClientTestCase
         $users = $this->client->listProjectUsers($project['id']);
         $this->assertCount(0, $users);
     }
-
-    private function findOrganizationMember(int $organizationId, string $userEmail): ?array
-    {
-        $members = $this->client->listOrganizationUsers($organizationId);
-
-        foreach ($members as $member) {
-            if ($member['email'] === $userEmail) {
-                return $member;
-            }
-        }
-
-        return null;
-    }
-
-    private function findMaintainerMember(int $maintainerId, string $userEmail): ?array
-    {
-        $members = $this->client->listMaintainerMembers($maintainerId);
-
-        foreach ($members as $member) {
-            if ($member['email'] === $userEmail) {
-                return $member;
-            }
-        }
-
-        return null;
-    }
 }


### PR DESCRIPTION
Pozvanky do organizace:

- rozsireni klienta
- testy
- update apiary dokumentace

Zaroven jsem trochu preskladal testy pozvanek a join requestu organizace a projektu:

- `findProjectUser()` + `findOrganizationMember()` + `findMaintainerMember()` presunuto do `ClientTestCase`
- uprava init prostredi v `setUp()` _(diky novemu limitu na min. 1 clena maintanera)_
