### PR TITLE
fixup: testInvitationAttributesPropagationToProjectMembership

### DIFF
--- a/tests/ProjectInvitationsTest.php
+++ b/tests/ProjectInvitationsTest.php
@@ -572,9 +572,9 @@ class ProjectInvitationsTest extends ClientTestCase
         $this->assertEquals('guest', $invitation['role']);
         $this->assertNotEmpty($invitation['expires']);
 
-        $this->client->acceptMyProjectInvitation($invitation['id']);
+        $this->normalUserClient->acceptMyProjectInvitation($invitation['id']);
 
-        $invitations = $this->client->listMyProjectInvitations();
+        $invitations = $this->normalUserClient->listMyProjectInvitations();
         $this->assertCount(0, $invitations);
 
         $projectUser = $this->findProjectUser($projectId, $this->normalUser['email']);


### PR DESCRIPTION
V puvodnim PR https://github.com/keboola/kbc-manage-api-php-client/pull/74 byla chybka v testech ktera rozbila build connection

Test zve `normalUsera` do projektu a ten si pak ma schvalit pozvanku. 