### PR TITLE
KBC-177 synapse backend tests

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3156,6 +3156,10 @@ According to the previous example, the parameters for creating Storage will be:
 - `password` - `YOUR_PASSWORD`
 
 
+#### Synapse
+
+Credentials for sql server admin must be provided with database name.
+
 + Request (application/json)
 
     + Headers
@@ -3172,29 +3176,47 @@ According to the previous example, the parameters for creating Storage will be:
 
 + Response 200 (application/json)
 
-    + Attributes (array[StorageBackend])
+    + Attributes (array[StorageBackendList])
 
 
 ## Data Structures
 
 ### StorageBackendCreate
 
-+ backend: Snowflake (required) - can be Redshift or Snowflake
++ backend: Snowflake (required) - can be Redshift, Snowflake or Synapse
 + host: `sapi-37-demo.cmizbsfmzc6w.us-east-1.redshift.amazonaws.com` (required)
 + warehouse: `production` - required only for Snowflake
 + username: keboola (required)
 + password: 1234 (required)
-+ region: `us-east-1` (required)
++ region: `us-east-1` - required only for Snowflake and Redshift
 + owner: keboola (required) - associated AWS account owner
++ database: MyDataWarehouse - required only for Synapse
 
 ## StorageBackend
 
 + id: 123 (required)
-+ backend: redshift (required)
 + host: sapi-37-demo.cmizbsfmzc6w.us-east-1.redshift.amazonaws.com (required)
-+ username: keboola (required)
-+ password: 1234 (required)
++ backend: redshift (required)
++ region: us-east-1
+
+## StorageBackendList
+
++ id: 123 (required)
++ host: sapi-37-demo.cmizbsfmzc6w.us-east-1.redshift.amazonaws.com (required)
++ backend: redshift (required)
++ region: us-east-1 (required)
 + owner: keboola (required)
++ stats
+    + projectsCount: 10 (required)
+    + bucketsCount: 100 (required)
+    + dataSizeGB: 100 (required)
+    + rowsCount: 1000000 (required)
++ created: 2008-05-11T15:30:00Z datetime ISO8601 'Y-m-d\TH:i:sO' (required)
++ creator
+    + id: 10 (required)
+    + name: keboola (required)
++ warehouse: keboola
++ database: keboola
 
 
 # Group SUPER - Commands

--- a/src/Backend.php
+++ b/src/Backend.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ManageApi;
+
+final class Backend
+{
+    public const REDSHIFT = 'redshift';
+    public const SNOWFLAKE = 'snowflake';
+    public const SYNAPSE = 'synapse';
+
+    public static function getDefaultBackend(): string
+    {
+        return self::SNOWFLAKE;
+    }
+}

--- a/tests/BackendTest.php
+++ b/tests/BackendTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ManageApiTest;
+
+use Keboola\ManageApi\Backend;
+
+class BackendTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultBackend()
+    {
+        $this->assertEquals('snowflake', Backend::getDefaultBackend());
+    }
+}

--- a/tests/FileStorageAbsTest.php
+++ b/tests/FileStorageAbsTest.php
@@ -10,7 +10,7 @@ use function GuzzleHttp\json_encode;
  */
 class FileStorageAbsTest extends ClientTestCase
 {
-    private const DEFAULT_ABS_OPTIONS = [
+    public const DEFAULT_ABS_OPTIONS = [
         'accountName' => TEST_ABS_ACCOUNT_NAME,
         'accountKey' => TEST_ABS_ACCOUNT_KEY,
         'containerName' => TEST_ABS_CONTAINER_NAME,

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -2,11 +2,21 @@
 
 namespace Keboola\ManageApiTest;
 
+use Keboola\ManageApi\Backend;
 use Keboola\ManageApi\ClientException;
 use Keboola\StorageApi\Client;
 
 class ProjectsTest extends ClientTestCase
 {
+    public function supportedBackends(): array
+    {
+        return [
+            [Backend::SNOWFLAKE],
+            [Backend::REDSHIFT],
+            [Backend::SYNAPSE],
+        ];
+    }
+
     /**
      * @return array
      */
@@ -246,9 +256,12 @@ class ProjectsTest extends ClientTestCase
         $this->assertNotEmpty($project['expires']);
     }
 
-    public function testCreateProjectWithRedshiftBackend()
+    /**
+     * @dataProvider supportedBackends
+     * @param string $backend
+     */
+    public function testCreateProjectWithBackend(string $backend): void
     {
-        $backend = 'redshift';
         $organization = $this->client->createOrganization($this->testMaintainerId, [
             'name' => 'My org',
         ]);
@@ -260,7 +273,6 @@ class ProjectsTest extends ClientTestCase
 
         $this->assertEquals($backend, $project['defaultBackend']);
     }
-
 
     public function testCreateProjectWithRedshiftBackendFromTemplate()
     {

--- a/tests/StorageBackendTest.php
+++ b/tests/StorageBackendTest.php
@@ -2,25 +2,35 @@
 
 namespace Keboola\ManageApiTest;
 
+use Keboola\ManageApi\Backend;
 use Keboola\ManageApi\ClientException;
-use Keboola\StorageApi\Client;
 
 class StorageBackendTest extends ClientTestCase
 {
-
-    public function testStorageAssignRedshiftBackend()
+    public function supportedNonDefaultBackends(): array
     {
-        // get redshift backend
+        return [
+            [Backend::REDSHIFT],
+            [Backend::SYNAPSE],
+        ];
+    }
+
+    /**
+     * @dataProvider supportedNonDefaultBackends
+     * @param string $backendName
+     */
+    public function testStorageAssignBackend(string $backendName): void
+    {
+        // get redshift and synapse backend
         $backends = $this->client->listStorageBackend();
-        $redshiftBackend = null;
-        foreach ($backends as $backend) {
-            if ($backend['backend'] == 'redshift') {
-                $redshiftBackend = $backend;
-                break;
+        $backendToAssign = null;
+        foreach ($backends as $item) {
+            if ($item['backend'] === $backendName) {
+                $backendToAssign = $item;
             }
         }
-        if (!$redshiftBackend) {
-            $this->fail('Redshift backend not found');
+        if (!$backendToAssign) {
+            $this->fail(sprintf('%s backend not found', ucfirst($backendName)));
         }
 
         $name = 'My org';
@@ -35,27 +45,31 @@ class StorageBackendTest extends ClientTestCase
         $this->assertArrayHasKey('backends', $project);
         $this->assertEquals('snowflake', $project['defaultBackend']);
 
+        if ($backendName === Backend::SYNAPSE) {
+            $storage = $this->client->createAbsFileStorage(FileStorageAbsTest::DEFAULT_ABS_OPTIONS);
+            $this->client->assignFileStorage($project['id'], $storage['id']);
+        }
+
         $backends = $project['backends'];
 
         $this->assertArrayHasKey('snowflake', $backends);
-        $this->assertArrayNotHasKey('redshift', $backends);
+        $this->assertArrayNotHasKey($backendName, $backends);
 
-        $this->client->assignProjectStorageBackend($project['id'], $redshiftBackend['id']);
+        $this->client->assignProjectStorageBackend($project['id'], $backendToAssign['id']);
 
         $project = $this->client->getProject($project['id']);
         $backends = $project['backends'];
 
-        $this->assertArrayHasKey('redshift', $backends);
-        $this->assertEquals('redshift', $project['defaultBackend']);
+        $this->assertArrayHasKey($backendName, $backends);
+        $this->assertEquals($backendName, $project['defaultBackend']);
 
-        $redshift = $backends['redshift'];
-        $this->assertEquals($redshiftBackend['id'], $redshift['id']);
+        $this->assertEquals($backendToAssign['id'], $backends[$backendName]['id']);
 
         // let's try to create a bucket in project now
 
         $token = $this->client->createProjectStorageToken($project['id'], [
             'description' => 'test',
-            'expiresIn' => 60,
+            'expiresIn' => 120,
             'canManageBuckets' => true,
         ]);
 
@@ -65,11 +79,11 @@ class StorageBackendTest extends ClientTestCase
         ]);
         $bucketId = $sapiClient->createBucket('test', 'in');
         $bucket = $sapiClient->getBucket($bucketId);
-        $this->assertEquals('redshift', $bucket['backend']);
+        $this->assertEquals($backendName, $bucket['backend']);
 
         $sapiClient->dropBucket($bucketId);
 
-        $this->client->removeProjectStorageBackend($project['id'], $redshiftBackend['id']);
+        $this->client->removeProjectStorageBackend($project['id'], $backendToAssign['id']);
     }
 
     public function testStorageBackendList()

--- a/tests/StorageBackendTest.php
+++ b/tests/StorageBackendTest.php
@@ -69,7 +69,7 @@ class StorageBackendTest extends ClientTestCase
 
         $token = $this->client->createProjectStorageToken($project['id'], [
             'description' => 'test',
-            'expiresIn' => 120,
+            'expiresIn' => 60,
             'canManageBuckets' => true,
         ]);
 


### PR DESCRIPTION
updated tests:
- `ProjectsTest::testCreateProjectWithRedshiftBackend` -> `ProjectsTest::testCreateProjectWithBackend` added dataprovider with redshift|snowflake|synapse
- `StorageBackendTest::testStorageAssignRedshiftBackend` -> `StorageBackendTest::testStorageAssignBackend` added dataprovider with redshift|synapse

New class `Backend` which contains constants with backend names

Updated apib file with endpoint definition

Možné přidat až s https://github.com/keboola/connection/pull/2369