### PR TITLE
ProjectDeleteTest::testDeleteAndPurgeProjectWithData purge timeout 5 minutes

### DIFF
--- a/tests/ProjectDeleteTest.php
+++ b/tests/ProjectDeleteTest.php
@@ -272,7 +272,7 @@ class ProjectDeleteTest extends ClientTestCase
 
         // purge all data async
         $startTime = time();
-        $maxWaitTimeSeconds = 120;
+        $maxWaitTimeSeconds = 5 * 60;
         $purgeResponse = $this->client->purgeDeletedProject($project['id']);
         $this->assertArrayHasKey('commandExecutionId', $purgeResponse);
         $this->assertNotNull($purgeResponse['commandExecutionId']);


### PR DESCRIPTION
Zvyseni purge timeoutu. Casto nam nestiha dobehnout do dvou minut kdyz poustime testy paralelne.