### PR TITLE
Fix Exception constructor parameters types (in phpDoc)

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,11 +10,11 @@ class Exception extends \Exception
     /**
      * Construct the exception
      *
-     * @param null $message
-     * @param  int $code
-     * @param  \Exception $previous
-     * @param  string $stringCode
-     * @param  mixed|array $params
+     * @param string|null $message
+     * @param int|null $code
+     * @param \Exception|null $previous
+     * @param string|null $stringCode
+     * @param mixed $params
      */
     public function __construct($message = null, $code = null, $previous = null, $stringCode = null, $params = null)
     {


### PR DESCRIPTION
Nema to zadne issue v Jire. Vsiml jsem si toho, kdyz mi PHPStan zacal rvat, ze $message muze byt jen null.

Stejny problem jako https://github.com/keboola/storage-api-php-client/pull/635