### PR TITLE
KBC-1982 fix dataRetentionTimeInDays

### DIFF
--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -1528,7 +1528,7 @@ class ProjectsTest extends ClientTestCase
         $organization = $this->initTestOrganization();
         $project = $this->initTestProject($organization['id']);
 
-        $this->assertEquals(7, (int) $project['dataRetentionTimeInDays']);
+        $this->assertEquals(1, (int) $project['dataRetentionTimeInDays']);
 
         // verify that normal users can't update data retention time
         try {

--- a/tests/StorageBackendTest.php
+++ b/tests/StorageBackendTest.php
@@ -32,6 +32,7 @@ class StorageBackendTest extends ClientTestCase
 
         $project = $this->client->createProject($organization['id'], [
             'name' => 'My test',
+            'dataRetentionTimeInDays' => 1,
         ]);
 
         try {


### PR DESCRIPTION
Jira: KBC-1982

Spadle testy:
```
11:50:24-UTC - manage                             -	1) Keboola\ManageApiTest\ProjectsTest::testProjectDataRetention
11:50:24-UTC - manage                             -	Failed asserting that 1 matches expected 7.
```
```
11:50:24-UTC - manage                             -	1) Keboola\ManageApiTest\StorageBackendTest::testCreateStorageBackend with data set "snowflake" (array('snowflake', 'keboolaconnectiondev.us-east-...ng.com', 'DEV', '[secure]', '[secure]', 'us-east-1', 'keboola'))
11:50:24-UTC - manage                             -	Keboola\ManageApi\ClientException: Application error.

odbc_prepare(): SQL error: SQL compilation error:\nExceeds maximum allowable retention time (1)., SQL state 22023 in SQLPrepare
```