### PR TITLE
show type parameter only for retrieve all call

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2998,9 +2998,9 @@ To create a new promo-code, provide the following parameters as JSON in the requ
 
 # Group SUPER - Features
 
-## Features [/manage/features?type={type}]
+## Features [/manage/features]
 
-### Retrieve all features [GET]
+### Retrieve all features [GET /manage/features?type={type}]
 
 Gets all features. To filter only the features with a specific type,
 add the `type` parameter to your query.


### PR DESCRIPTION
u endpointu [Create Feature](https://keboolamanagementapi.docs.apiary.io/#reference/super-features/features/create-a-feature) se zobrazoval parametr v `url`, i kdyz je v JSONu.