### PR TITLE
Disable creating EXA projects until EXA will re-enabled again

### DIFF
--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -21,7 +21,7 @@ class ProjectsTest extends ClientTestCase
             [Backend::SNOWFLAKE],
             [Backend::REDSHIFT],
             [Backend::SYNAPSE],
-            [Backend::EXASOL],
+//            [Backend::EXASOL], // tmp disable until exasol will work again
         ];
     }
 


### PR DESCRIPTION
disable testing of creating new EXA projects until EXA won't be enabled again https://github.com/keboola/connection/pull/3523 (it doesnt start the DBs on the beginning of the build)