### PR TITLE
Update deprecated phpunit asserts

### DIFF
--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -11,7 +11,7 @@ class CommonTest extends ClientTestCase
     {
         $token = $this->client->verifyToken();
 
-        $this->assertInternalType('int', $token['id']);
+        $this->assertIsInt($token['id']);
         $this->assertNotEmpty($token['description']);
         $this->assertNotEmpty($token['created']);
         $this->assertFalse($token['isDisabled']);
@@ -37,7 +37,7 @@ class CommonTest extends ClientTestCase
         ]);
         $token = $client->verifyToken();
 
-        $this->assertInternalType('int', $token['id']);
+        $this->assertIsInt($token['id']);
         $this->assertNotEmpty($token['description']);
         $this->assertNotEmpty($token['created']);
         $this->assertFalse($token['isDisabled']);

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -16,7 +16,7 @@ class CommonTest extends ClientTestCase
         $this->assertNotEmpty($token['created']);
         $this->assertFalse($token['isDisabled']);
         $this->assertFalse($token['isExpired']);
-        $this->assertInternalType('array', $token['scopes']);
+        $this->assertIsArray($token['scopes']);
         $this->assertEquals($token['type'], 'admin');
         $this->assertNotEmpty($token['lastUsed']);
         $this->assertFalse($token['isSessionToken']);
@@ -42,7 +42,7 @@ class CommonTest extends ClientTestCase
         $this->assertNotEmpty($token['created']);
         $this->assertFalse($token['isDisabled']);
         $this->assertFalse($token['isExpired']);
-        $this->assertInternalType('array', $token['scopes']);
+        $this->assertIsArray($token['scopes']);
         $this->assertEquals($token['type'], 'super');
         $this->assertFalse($token['isSessionToken']);
     }

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -71,7 +71,7 @@ class CommonTest extends ClientTestCase
             );
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('Request body not valid', (string) $e->getResponse()->getBody());
+            $this->assertStringContainsString('Request body not valid', (string) $e->getResponse()->getBody());
         }
     }
 }

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -128,7 +128,7 @@ class FeaturesTest extends ClientTestCase
         $featureProjects = $this->client->getFeatureProjects($insertedFeature['id']);
 
         $this->assertNotEmpty($featureProjects);
-        $this->assertInternalType('array', $featureProjects);
+        $this->assertIsArray($featureProjects);
 
         $projectFound = null;
 
@@ -168,7 +168,7 @@ class FeaturesTest extends ClientTestCase
         $featureAdmins = $this->client->getFeatureAdmins($insertedFeature['id']);
 
         $this->assertNotEmpty($featureAdmins);
-        $this->assertInternalType('array', $featureAdmins);
+        $this->assertIsArray($featureAdmins);
 
         $adminFound = null;
 

--- a/tests/MaintainerInvitationsTest.php
+++ b/tests/MaintainerInvitationsTest.php
@@ -212,8 +212,8 @@ class MaintainerInvitationsTest extends ClientTestCase
             $this->fail('Invite user to maintainer twice should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('invited', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('invited', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);
@@ -233,8 +233,8 @@ class MaintainerInvitationsTest extends ClientTestCase
             $this->fail('Invite existing member to maintainer should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('member', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('member', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listMaintainerInvitations($maintainerId);

--- a/tests/MaintainerJoinTest.php
+++ b/tests/MaintainerJoinTest.php
@@ -108,7 +108,7 @@ class MaintainerJoinTest extends ClientTestCase
             $this->normalUserClient->joinMaintainer($maintainerId);
             $this->fail('Maintainer join should produce error');
         } catch (ClientException $e) {
-            $this->assertContains('already a member', $e->getMessage());
+            $this->assertStringContainsString('already a member', $e->getMessage());
             $this->assertEquals(400, $e->getCode());
         }
 

--- a/tests/MaintainersTest.php
+++ b/tests/MaintainersTest.php
@@ -232,7 +232,7 @@ class MaintainersTest extends ClientTestCase
 
         $maintainer = $maintainers[0];
 
-        $this->assertInternalType('int', $maintainer['id']);
+        $this->assertIsInt($maintainer['id']);
         $this->assertNotEmpty($maintainer['name']);
         $this->assertNotEmpty($maintainer['created']);
         $this->assertArrayHasKey('defaultConnectionMysqlId', $maintainer);

--- a/tests/MaintainersTest.php
+++ b/tests/MaintainersTest.php
@@ -267,7 +267,7 @@ class MaintainersTest extends ClientTestCase
             $this->fail('The last member could not be removed from the maintainer');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('least 1 member', $e->getMessage());
+            $this->assertStringContainsString('least 1 member', $e->getMessage());
         }
 
         $members = $this->client->listMaintainerMembers($maintainerId);

--- a/tests/OrganizationInvitationsTest.php
+++ b/tests/OrganizationInvitationsTest.php
@@ -308,8 +308,8 @@ class OrganizationInvitationsTest extends ClientTestCase
             $this->fail('Invite user to organization twice should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('invited', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('invited', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listOrganizationInvitations($organizationId);
@@ -330,8 +330,8 @@ class OrganizationInvitationsTest extends ClientTestCase
             $this->fail('Invite existing member to organization should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('member', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('member', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listOrganizationInvitations($organizationId);

--- a/tests/OrganizationJoinMfaValidationTest.php
+++ b/tests/OrganizationJoinMfaValidationTest.php
@@ -46,7 +46,7 @@ class OrganizationJoinMfaValidationTest extends ClientMfaTestCase
             $this->fail('Organization join should be restricted for admins without MFA');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This organization requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This organization requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $member = $this->findOrganizationMember($this->organization['id'], $this->superAdmin['email']);
@@ -69,7 +69,7 @@ class OrganizationJoinMfaValidationTest extends ClientMfaTestCase
             $this->fail('Organization join should be restricted for admins without MFA');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This organization requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This organization requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $member = $this->findOrganizationMember($this->organization['id'], $this->normalUser['email']);

--- a/tests/OrganizationMfaValidationTest.php
+++ b/tests/OrganizationMfaValidationTest.php
@@ -42,7 +42,7 @@ class OrganizationMfaValidationTest extends ClientMfaTestCase
             $this->fail('Change of multi-factor authentication attribute should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('Only organization members can change the \'mfaRequired\' parameter', $e->getMessage());
+            $this->assertStringContainsString('Only organization members can change the \'mfaRequired\' parameter', $e->getMessage());
         }
 
         $this->assertSame(false, $this->organization['mfaRequired']);
@@ -59,7 +59,7 @@ class OrganizationMfaValidationTest extends ClientMfaTestCase
             $this->fail('Change of multi-factor authentication attribute should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('Only organization members can change the \'mfaRequired\' parameter', $e->getMessage());
+            $this->assertStringContainsString('Only organization members can change the \'mfaRequired\' parameter', $e->getMessage());
         }
 
         $this->assertSame(false, $this->organization['mfaRequired']);
@@ -91,7 +91,7 @@ class OrganizationMfaValidationTest extends ClientMfaTestCase
             $this->fail('Change of multi-factor authentication attribute should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('Not all organization and project members have Multi-factor Authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('Not all organization and project members have Multi-factor Authentication enabled', $e->getMessage());
         }
 
         $this->assertSame(false, $this->organization['mfaRequired']);
@@ -114,7 +114,7 @@ class OrganizationMfaValidationTest extends ClientMfaTestCase
             $this->fail('Change of multi-factor authentication attribute should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('Not all organization and project members have Multi-factor Authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('Not all organization and project members have Multi-factor Authentication enabled', $e->getMessage());
         }
 
         $this->assertSame(false, $this->organization['mfaRequired']);
@@ -134,7 +134,7 @@ class OrganizationMfaValidationTest extends ClientMfaTestCase
             $this->fail('Adding admins without MFA to organization should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This organization requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This organization requires users to have multi-factor authentication enabled', $e->getMessage());
         }
     }
 

--- a/tests/OrganizationsTest.php
+++ b/tests/OrganizationsTest.php
@@ -46,7 +46,7 @@ class OrganizationsTest extends ClientTestCase
             $this->fail('The last member could not be removed from the organization');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('least 1 member', $e->getMessage());
+            $this->assertStringContainsString('least 1 member', $e->getMessage());
         }
 
         $members = $this->client->listOrganizationUsers($organizationId);

--- a/tests/OrganizationsTest.php
+++ b/tests/OrganizationsTest.php
@@ -18,7 +18,7 @@ class OrganizationsTest extends ClientTestCase
         $this->assertGreaterThan(0, count($organizations));
 
         $organization = $organizations[0];
-        $this->assertInternalType('int', $organization['id']);
+        $this->assertIsInt($organization['id']);
         $this->assertNotEmpty($organization['name']);
         $this->assertArrayHasKey('maintainer', $organization);
     }

--- a/tests/ProjectInvitationsMfaValidationTest.php
+++ b/tests/ProjectInvitationsMfaValidationTest.php
@@ -65,7 +65,7 @@ class ProjectInvitationsMfaValidationTest extends ClientMfaTestCase
             $this->fail('Accept invitation to project should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $invitations = $this->normalUserWithMfaClient->listProjectInvitations($projectId);

--- a/tests/ProjectInvitationsTest.php
+++ b/tests/ProjectInvitationsTest.php
@@ -387,8 +387,8 @@ class ProjectInvitationsTest extends ClientTestCase
             $this->fail('Invite user to project twice should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('invited', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('invited', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listProjectInvitations($projectId);
@@ -408,8 +408,8 @@ class ProjectInvitationsTest extends ClientTestCase
             $this->fail('Invite existing member to project should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('member', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('member', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listProjectInvitations($projectId);
@@ -429,7 +429,7 @@ class ProjectInvitationsTest extends ClientTestCase
             $this->fail('Invite yourself to project should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('You cannot invite yourself', $e->getMessage());
+            $this->assertStringContainsString('You cannot invite yourself', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listProjectInvitations($projectId);
@@ -458,7 +458,7 @@ class ProjectInvitationsTest extends ClientTestCase
             $this->fail('Invite user having join request should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This user has already requested access', $e->getMessage());
+            $this->assertStringContainsString('This user has already requested access', $e->getMessage());
         }
 
         $invitations = $this->normalUserClient->listProjectInvitations($projectId);
@@ -671,7 +671,7 @@ class ProjectInvitationsTest extends ClientTestCase
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
             $this->assertRegExp('/Role .* is not valid. Allowed roles are: admin, guest/', $e->getMessage());
-            $this->assertContains('invalid-role', $e->getMessage());
+            $this->assertStringContainsString('invalid-role', $e->getMessage());
         }
 
         $invitations = $this->client->listProjectInvitations($projectId);

--- a/tests/ProjectJoinMfaValidationTest.php
+++ b/tests/ProjectJoinMfaValidationTest.php
@@ -49,7 +49,7 @@ class ProjectJoinMfaValidationTest extends ClientMfaTestCase
             $this->fail('Joining a project should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $projectUser = $this->findProjectUser($projectId, $this->superAdmin['email']);

--- a/tests/ProjectJoinRequestsMfaValidationTest.php
+++ b/tests/ProjectJoinRequestsMfaValidationTest.php
@@ -62,7 +62,7 @@ class ProjectJoinRequestsMfaValidationTest extends ClientMfaTestCase
             $this->fail('Requesting access to a project should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $joinRequests = $this->normalUserWithMfaClient->listProjectJoinRequests($projectId);
@@ -102,7 +102,7 @@ class ProjectJoinRequestsMfaValidationTest extends ClientMfaTestCase
             $this->fail('Approving a join request should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $joinRequests = $this->client->listMyProjectJoinRequests();

--- a/tests/ProjectJoinRequestsTest.php
+++ b/tests/ProjectJoinRequestsTest.php
@@ -178,7 +178,7 @@ class ProjectJoinRequestsTest extends ClientTestCase
             $this->normalUserClient->requestAccessToProject($projectId);
             $this->fail('Request access should produce error');
         } catch (ClientException $e) {
-            $this->assertContains('use join-project method', $e->getMessage());
+            $this->assertStringContainsString('use join-project method', $e->getMessage());
             $this->assertEquals(400, $e->getCode());
         }
 
@@ -243,8 +243,8 @@ class ProjectJoinRequestsTest extends ClientTestCase
             $this->fail('Request access should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('member', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('member', $e->getMessage());
         }
 
         $joinRequests = $this->normalUserClient->listProjectJoinRequests($projectId);
@@ -733,8 +733,8 @@ class ProjectJoinRequestsTest extends ClientTestCase
             $this->fail('Request access to project twice should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('already', $e->getMessage());
-            $this->assertContains('sent', $e->getMessage());
+            $this->assertStringContainsString('already', $e->getMessage());
+            $this->assertStringContainsString('sent', $e->getMessage());
         }
 
         $joinRequests = $this->client->listProjectJoinRequests($projectId);
@@ -759,7 +759,7 @@ class ProjectJoinRequestsTest extends ClientTestCase
             $this->fail('Request access of invited user should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('You have been already invited', $e->getMessage());
+            $this->assertStringContainsString('You have been already invited', $e->getMessage());
         }
 
         $joinRequests = $this->client->listProjectJoinRequests($projectId);

--- a/tests/ProjectJoinTest.php
+++ b/tests/ProjectJoinTest.php
@@ -173,7 +173,7 @@ class ProjectJoinTest extends ClientTestCase
             $this->fail('Project token create should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(403, $e->getCode());
-            $this->assertContains('You don\'t have access to project', $e->getMessage());
+            $this->assertStringContainsString('You don\'t have access to project', $e->getMessage());
         }
     }
 
@@ -225,7 +225,7 @@ class ProjectJoinTest extends ClientTestCase
             $this->fail('Project token create should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(403, $e->getCode());
-            $this->assertContains('You don\'t have access to project', $e->getMessage());
+            $this->assertStringContainsString('You don\'t have access to project', $e->getMessage());
         }
     }
 
@@ -394,7 +394,7 @@ class ProjectJoinTest extends ClientTestCase
             $this->fail('Project token create should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(403, $e->getCode());
-            $this->assertContains('You don\'t have access to project', $e->getMessage());
+            $this->assertStringContainsString('You don\'t have access to project', $e->getMessage());
         }
     }
 

--- a/tests/ProjectMembershipRolesTest.php
+++ b/tests/ProjectMembershipRolesTest.php
@@ -472,6 +472,6 @@ class ProjectMembershipRolesTest extends ClientMfaTestCase
     private function restrictedActionTest(ClientException $e)
     {
         $this->assertEquals(403, $e->getCode());
-        $this->assertContains('Action is restricted for your role', $e->getMessage());
+        $this->assertStringContainsString('Action is restricted for your role', $e->getMessage());
     }
 }

--- a/tests/ProjectMfaValidationTest.php
+++ b/tests/ProjectMfaValidationTest.php
@@ -50,7 +50,7 @@ class ProjectMfaValidationTest extends ClientMfaTestCase
             $this->fail('Adding admins without MFA to project should produce error');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $member = $this->findProjectUser($projectId, $this->normalUser['email']);

--- a/tests/ProjectTemplatesTest.php
+++ b/tests/ProjectTemplatesTest.php
@@ -114,7 +114,7 @@ class ProjectTemplatesTest extends ClientTestCase
         $this->assertEquals(15, $template['expirationDays']);
         $this->assertIsInt($template['expirationDays']);
         $this->assertEquals(true, $template['hasTryModeOn']);
-        $this->assertInternalType('boolean', $template['hasTryModeOn']);
+        $this->assertIsBool($template['hasTryModeOn']);
     }
 
     public function testOrganizationAdminCannotViewHiddenProjectTemplate()

--- a/tests/ProjectTemplatesTest.php
+++ b/tests/ProjectTemplatesTest.php
@@ -112,7 +112,7 @@ class ProjectTemplatesTest extends ClientTestCase
         $this->assertArrayHasKey('hasTryModeOn', $template);
 
         $this->assertEquals(15, $template['expirationDays']);
-        $this->assertInternalType('int', $template['expirationDays']);
+        $this->assertIsInt($template['expirationDays']);
         $this->assertEquals(true, $template['hasTryModeOn']);
         $this->assertInternalType('boolean', $template['hasTryModeOn']);
     }

--- a/tests/ProjectsMetadataTest.php
+++ b/tests/ProjectsMetadataTest.php
@@ -926,7 +926,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         try {
@@ -934,7 +934,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         try {
@@ -942,7 +942,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $metadata = reset($metadata);
@@ -952,7 +952,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $this->assertCount(2, $this->normalUserWithMfaClient->listProjectMetadata($projectId));
@@ -978,7 +978,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         try {
@@ -986,7 +986,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $metadata = reset($metadata);
@@ -996,7 +996,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $this->assertCount(2, $this->normalUserWithMfaClient->listProjectMetadata($projectId));
@@ -1017,7 +1017,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         try {
@@ -1025,7 +1025,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $metadata = reset($metadata);
@@ -1035,7 +1035,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $this->assertCount(2, $this->normalUserWithMfaClient->listProjectMetadata($projectId));
@@ -1065,7 +1065,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         try {
@@ -1073,7 +1073,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $metadata = reset($metadata);
@@ -1083,7 +1083,7 @@ class ProjectsMetadataTest extends ClientTestCase
             $this->fail('Should fail.');
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertContains('This project requires users to have multi-factor authentication enabled', $e->getMessage());
+            $this->assertStringContainsString('This project requires users to have multi-factor authentication enabled', $e->getMessage());
         }
 
         $this->assertCount(2, $this->normalUserWithMfaClient->listProjectMetadata($projectId));

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -216,12 +216,12 @@ class ProjectsTest extends ClientTestCase
         $limitKeys = array_keys($foundProject['limits']);
         $this->assertArrayHasKey('name', $firstLimit);
         $this->assertArrayHasKey('value', $firstLimit);
-        $this->assertInternalType('int', $firstLimit['value']);
+        $this->assertIsInt($firstLimit['value']);
         $this->assertEquals($firstLimit['name'], $limitKeys[0]);
 
         $this->assertArrayHasKey('fileStorage', $project);
         $fileStorage = $project['fileStorage'];
-        $this->assertInternalType('int', $fileStorage['id']);
+        $this->assertIsInt($fileStorage['id']);
         $this->assertArrayHasKey('awsKey', $fileStorage);
         $this->assertArrayHasKey('region', $fileStorage);
         $this->assertArrayHasKey('filesBucket', $fileStorage);
@@ -232,7 +232,7 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('snowflake', $backends);
 
         $snowflake = $backends['snowflake'];
-        $this->assertInternalType('int', $snowflake['id']);
+        $this->assertIsInt($snowflake['id']);
         $this->assertArrayHasKey('host', $snowflake);
 
         return $foundProject;
@@ -1791,7 +1791,7 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('payAsYouGo', $project);
 
         $payAsYouGo = $project['payAsYouGo'];
-        $this->assertInternalType('integer', $payAsYouGo['purchasedCredits']);
+        $this->assertIsInt($payAsYouGo['purchasedCredits']);
 
         $projects = $this->client->listOrganizationProjects($organization['id']);
         $this->assertCount(1, $projects);
@@ -1801,7 +1801,7 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('payAsYouGo', $project);
 
         $payAsYouGo = $project['payAsYouGo'];
-        $this->assertInternalType('integer', $payAsYouGo['purchasedCredits']);
+        $this->assertIsInt($payAsYouGo['purchasedCredits']);
     }
 
     public function testCreditsCannotBeGivenToNonPaygoProject(): void
@@ -1850,7 +1850,7 @@ class ProjectsTest extends ClientTestCase
         ]);
 
         $this->assertArrayHasKey('id', $response);
-        $this->assertInternalType('int', $response['id']);
+        $this->assertIsInt($response['id']);
         $this->assertArrayHasKey('creditsAmount', $response);
         $this->assertSame(100, $response['creditsAmount']);
         $this->assertArrayHasKey('moneyAmount', $response);
@@ -1892,7 +1892,7 @@ class ProjectsTest extends ClientTestCase
         ]);
 
         $this->assertArrayHasKey('id', $response);
-        $this->assertInternalType('int', $response['id']);
+        $this->assertIsInt($response['id']);
         $this->assertArrayHasKey('creditsAmount', $response);
         $this->assertSame(100, $response['creditsAmount']);
         $this->assertArrayHasKey('moneyAmount', $response);

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -350,7 +350,7 @@ class ProjectsTest extends ClientTestCase
             $this->fail('RandomAdmin should be not allowed to create project');
         } catch (ClientException $e) {
             $this->assertEquals(403, $e->getCode());
-            $this->assertContains('You don\'t have access to the organization', $e->getMessage());
+            $this->assertStringContainsString('You don\'t have access to the organization', $e->getMessage());
         }
 
         $projects = $this->client->listOrganizationProjects($organizationId);
@@ -1733,7 +1733,7 @@ class ProjectsTest extends ClientTestCase
         } catch (ClientException $e) {
             $this->assertEquals(400, $e->getCode());
             $this->assertRegExp('/Role .* is not valid. Allowed roles are: admin, guest/', $e->getMessage());
-            $this->assertContains('invalid-role', $e->getMessage());
+            $this->assertStringContainsString('invalid-role', $e->getMessage());
         }
 
         $member = $this->findProjectUser($project['id'], $this->normalUser['email']);

--- a/tests/StorageBackendTest.php
+++ b/tests/StorageBackendTest.php
@@ -162,7 +162,7 @@ class StorageBackendTest extends ClientTestCase
         $this->assertNotEmpty($backends);
 
         $backend = reset($backends);
-        $this->assertInternalType('int', $backend['id']);
+        $this->assertIsInt($backend['id']);
         $this->assertArrayHasKey('host', $backend);
         $this->assertArrayHasKey('username', $backend);
         $this->assertArrayHasKey('backend', $backend);


### PR DESCRIPTION
```
17:10:52-UTC - manage                             -	There were 88 warnings:
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	1) Keboola\ManageApiTest\CommonTest::testVerifyAdminToken
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	2) Keboola\ManageApiTest\CommonTest::testVerifySuperToken
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	3) Keboola\ManageApiTest\CommonTest::testInvalidRequestBody
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	4) Keboola\ManageApiTest\FeaturesTest::testFeatureDetailProjects
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	5) Keboola\ManageApiTest\FeaturesTest::testFeatureDetailAdmins
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	6) Keboola\ManageApiTest\MaintainerInvitationsTest::testCannotInviteAlreadyInvitedUser
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	7) Keboola\ManageApiTest\MaintainerInvitationsTest::testCannotInviteExistingMember
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	8) Keboola\ManageApiTest\MaintainerJoinTest::testMaintainerMemberCannotJoinMaintainerAgain
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	9) Keboola\ManageApiTest\MaintainersTest::testListMaintainers
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	10) Keboola\ManageApiTest\MaintainersTest::testAtLeastOneMemberLimit
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	11) Keboola\ManageApiTest\OrganizationInvitationsTest::testCannotInviteAlreadyInvitedUser
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	12) Keboola\ManageApiTest\OrganizationInvitationsTest::testCannotInviteExistingMember
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	13) Keboola\ManageApiTest\OrganizationJoinMfaValidationTest::testSuperAdminWithoutMfaCannotJoinOrganization
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	14) Keboola\ManageApiTest\OrganizationJoinMfaValidationTest::testMaintainerAdminWithoutMfaCannotJoinOrganization
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	15) Keboola\ManageApiTest\OrganizationMfaValidationTest::testSuperAdminCannotChangeMfaAttribute
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	16) Keboola\ManageApiTest\OrganizationMfaValidationTest::testMaintainerAdminCannotChangeMfaAttribute
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	17) Keboola\ManageApiTest\OrganizationMfaValidationTest::testAllOrganizationMembersHaveMfaEnabledValidation
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	18) Keboola\ManageApiTest\OrganizationMfaValidationTest::testAllProjectsMembersHaveMfaEnabledValidation
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	19) Keboola\ManageApiTest\OrganizationMfaValidationTest::testAdminWithoutMfaCannotBecameMember
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	20) Keboola\ManageApiTest\OrganizationsTest::testListOrganizations
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	21) Keboola\ManageApiTest\OrganizationsTest::testLeastOneMemberLimit
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	22) Keboola\ManageApiTest\ProjectInvitationsMfaValidationTest::testInvitedAdminCannotAcceptInvitation
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	23) Keboola\ManageApiTest\ProjectInvitationsTest::testCannotInviteAlreadyInvitedUser
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	24) Keboola\ManageApiTest\ProjectInvitationsTest::testCannotInviteExistingMember
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	25) Keboola\ManageApiTest\ProjectInvitationsTest::testCannotInviteYourself
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	26) Keboola\ManageApiTest\ProjectInvitationsTest::testCannotInviteUserHavingJoinRequest
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	27) Keboola\ManageApiTest\ProjectInvitationsTest::testInviteUserToProjectWithInvalidRole
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	28) Keboola\ManageApiTest\ProjectJoinMfaValidationTest::testSuperAdminWithoutMfaCannotJoinProject
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	29) Keboola\ManageApiTest\ProjectJoinRequestsMfaValidationTest::testSuperAdminWithoutMfaCannotRequestAccess
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	30) Keboola\ManageApiTest\ProjectJoinRequestsMfaValidationTest::testJoinRequestOfUserWithoutMfaCannotBeApproved
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	31) Keboola\ManageApiTest\ProjectJoinRequestsTest::testOrganizationAdminCannotRequestAccessRegardlessOfAllowAutoJoin with data set #0 (true)
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	32) Keboola\ManageApiTest\ProjectJoinRequestsTest::testOrganizationAdminCannotRequestAccessRegardlessOfAllowAutoJoin with data set #1 (false)
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	33) Keboola\ManageApiTest\ProjectJoinRequestsTest::testProjectMemberCannotRequestAccessRegardlessOfAllowAutoJoin with data set #0 (true)
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	34) Keboola\ManageApiTest\ProjectJoinRequestsTest::testProjectMemberCannotRequestAccessRegardlessOfAllowAutoJoin with data set #1 (false)
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	35) Keboola\ManageApiTest\ProjectJoinRequestsTest::testCannotRequestAccessTwoTimes
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	36) Keboola\ManageApiTest\ProjectJoinRequestsTest::testInvitedAdminCannotRequestAccess
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	37) Keboola\ManageApiTest\ProjectJoinTest::testSuperAdminCannotCreateStorageTokenIfAllowAutoJoinIsDisabled
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	38) Keboola\ManageApiTest\ProjectJoinTest::testMaintainerAdminCannotCreateStorageTokenIfAllowAutoJoinIsDisabled
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	39) Keboola\ManageApiTest\ProjectJoinTest::testRandomAdminCannotCreateStorageTokenRegardlessOfAllowAutoJoin with data set #0 (true)
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	40) Keboola\ManageApiTest\ProjectJoinTest::testRandomAdminCannotCreateStorageTokenRegardlessOfAllowAutoJoin with data set #1 (false)
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	41) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotDeleteProject with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	42) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotDeleteProject with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	43) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotUpdateProject with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	44) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotUpdateProject with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	45) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotInviteAdministrator with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	46) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotInviteAdministrator with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	47) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotCancelAdministratorInvitation with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	48) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotCancelAdministratorInvitation with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	49) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotAddAdministrator with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	50) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotAddAdministrator with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	51) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotRemoveAdministrator with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	52) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotRemoveAdministrator with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	53) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotApproveOrDeclineJoinRequest with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	54) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotApproveOrDeclineJoinRequest with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	55) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotCreateStorageToken with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	56) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotCreateStorageToken with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	57) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotChangeMembershipRole with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	58) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotChangeMembershipRole with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	59) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotChangeOrganization with data set #0 ('guest')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	60) Keboola\ManageApiTest\ProjectMembershipRolesTest::testAdministratorWithLimitedRoleCannotChangeOrganization with data set #1 ('readOnly')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	61) Keboola\ManageApiTest\ProjectMfaValidationTest::testAdminWithoutMfaCannotBecameMember
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	62) Keboola\ManageApiTest\ProjectTemplatesTest::testTemplateDetail
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsBool() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	63) Keboola\ManageApiTest\ProjectsMetadataTest::testSuperAdminWithoutMfaCannotManageMetadata
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	64) Keboola\ManageApiTest\ProjectsMetadataTest::testMaintainerAdminWithoutMfaCannotManageMetadata
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	65) Keboola\ManageApiTest\ProjectsMetadataTest::testOrgAdminWithoutMfaCannotManageMetadata
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	66) Keboola\ManageApiTest\ProjectsMetadataTest::testProjectMemberWithoutMfaCannotManageMetadata with data set "admin" ('admin')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	67) Keboola\ManageApiTest\ProjectsMetadataTest::testProjectMemberWithoutMfaCannotManageMetadata with data set "share" ('share')
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	68) Keboola\ManageApiTest\ProjectsTest::testRandomAdminCannotCreateProject
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	69) Keboola\ManageApiTest\ProjectsTest::testOrganizationAdminCanCreateProject
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	70) Keboola\ManageApiTest\ProjectsTest::testListDeletedProjects
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	71) Keboola\ManageApiTest\ProjectsTest::testListDeletedProjectsPaging
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	72) Keboola\ManageApiTest\ProjectsTest::testDeletedProjectsErrors
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	73) Keboola\ManageApiTest\ProjectsTest::testProjectUnDelete
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	74) Keboola\ManageApiTest\ProjectsTest::testDeletedProjectDetail
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	75) Keboola\ManageApiTest\ProjectsTest::testActiveProjectUnDelete
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	76) Keboola\ManageApiTest\ProjectsTest::testProjectUnDeleteWithExpiration
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	77) Keboola\ManageApiTest\ProjectsTest::testProjectDataRetention
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	78) Keboola\ManageApiTest\ProjectsTest::testLastMemberCanLeaveProject
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	79) Keboola\ManageApiTest\ProjectsTest::testAddUserToProjectWithRole with data set #0 ('admin')
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	80) Keboola\ManageApiTest\ProjectsTest::testAddUserToProjectWithRole with data set #1 ('guest')
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	81) Keboola\ManageApiTest\ProjectsTest::testAddUserToProjectWithRole with data set #2 ('readOnly')
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	82) Keboola\ManageApiTest\ProjectsTest::testAddUserToProjectWithRole with data set #3 ('share')
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	83) Keboola\ManageApiTest\ProjectsTest::testAddUserToProjectWithInvalidRole
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	84) Keboola\ManageApiTest\ProjectsTest::testMembershipRoleChange
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	85) Keboola\ManageApiTest\ProjectsTest::testPayAsYoGoDetails
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	86) Keboola\ManageApiTest\ProjectsTest::testSuperAdminCanGiveProjectCredits
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	87) Keboola\ManageApiTest\ProjectsTest::testAdminWithFeatureCanGiveProjectCredits
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
17:10:52-UTC - manage                             -	
17:10:52-UTC - manage                             -	88) Keboola\ManageApiTest\StorageBackendTest::testStorageBackendList
17:10:52-UTC - manage                             -	assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsInt() instead.
```