### PR TITLE
fix float paygo credits

### DIFF
--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -1792,7 +1792,7 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('payAsYouGo', $project);
 
         $payAsYouGo = $project['payAsYouGo'];
-        $this->assertIsFloat($payAsYouGo['purchasedCredits']);
+        $this->assertIsNumeric($payAsYouGo['purchasedCredits']);
 
         $projects = $this->client->listOrganizationProjects($organization['id']);
         $this->assertCount(1, $projects);
@@ -1802,7 +1802,7 @@ class ProjectsTest extends ClientTestCase
         $this->assertArrayHasKey('payAsYouGo', $project);
 
         $payAsYouGo = $project['payAsYouGo'];
-        $this->assertIsFloat($payAsYouGo['purchasedCredits']);
+        $this->assertIsNumeric($payAsYouGo['purchasedCredits']);
     }
 
     public function testCreditsCannotBeGivenToNonPaygoProject(): void


### PR DESCRIPTION
Protoze se tady "jen" kontroluje, zda tam neco je, tak by melo stacit kontrolovat misto striktniho vyzadovani `float`, jestli je to cislo `numeric`.

Test na kontrolu `float` je napr `testSuperAdminCanGiveProjectCredits`.