### PR TITLE
PS-3279 Support Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php" : "^7.1|^8.0",
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^7.0|^6.1"
     },
     "require-dev": {
         "keboola/coding-standard": "^13.0",
@@ -47,6 +47,9 @@
     ],
     "config": {
         "sort-packages": true,
-        "lock": false
+        "lock": false,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PS-3279
Related to https://github.com/keboola/storage-api-php-client/pull/784

Allow using with Guzzle 7.

Guzzle has some breaking changes (https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70) but everything seems to work for me so far.