### PR TITLE
clean org and maintainer at the end of the test

### DIFF
--- a/tests/ProjectStorageBackendTest.php
+++ b/tests/ProjectStorageBackendTest.php
@@ -151,6 +151,8 @@ class ProjectStorageBackendTest extends ClientTestCase
         $this->waitForProjectPurge($project['id']);
 
         $this->client->removeStorageBackend($backend['id']);
+        $this->client->deleteOrganization($organization['id']);
+        $this->client->deleteMaintainer($maintainer['id']);
     }
 
     public function testStorageBackendRemove()


### PR DESCRIPTION
Jira: CT-XXX
Connection PR: XXXXX

Before asking for review make sure that:

## Checklist

- [x] New client method(s) has tests
- [x] Apiary file is updated
- [x] You declared if there is a BC break or not (will affect next release of a client)

## Release

- [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

---

I was looking for redshift projects on e2e and I found tons of maintainers and orgs -> this test does not clean after itself, so it should. There is no need for extra logic. if it fails and there will be an extra maintainer/org, nothing would happen