### PR TITLE
[CT-1944] Add test of new ui-apps isCritical flag

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4213,7 +4213,8 @@ Returns active applications. This resource doesn't require authentication.
             "styles": [
                 "https:\/\/kbc-uis.s3.amazonaws.com\/kbc.manageApps\/0.0.3-33-ga6bc947\/styles\/libs.css",
                 "https:\/\/kbc-uis.s3.amazonaws.com\/kbc.manageApps\/0.0.3-33-ga6bc947\/styles\/select2.png"
-            ]
+            ],
+            "isCritical": false
         }
     ]
     ```
@@ -4244,7 +4245,8 @@ Returns active applications. This resource doesn't require authentication.
             "id":1646,
             "created":"2015-08-17 17:43:37",
             "version":"0.1.21-17-g3cae4c0",
-            "isActive":true
+            "isActive":true,
+            "isCritical": false
         }
     }
     ```

--- a/tests/UiAppsTest.php
+++ b/tests/UiAppsTest.php
@@ -3,6 +3,7 @@
 namespace Keboola\ManageApiTest;
 
 use Keboola\ManageApi\Client;
+use Keboola\ManageApi\ClientException;
 
 class UiAppsTest extends ClientTestCase
 {
@@ -45,6 +46,33 @@ class UiAppsTest extends ClientTestCase
         $this->assertSame(count($listOfAppsBeforeCreation), (count($listOfAppsAfterCreation) - 1));
         $this->assertNotFalse(array_search($newAppName, $listOfAppsAfterCreation));
         $this->assertEquals($listOfAppsBeforeCreation, $listOfAppsAfterDeletion);
+    }
+
+    public function testAppCreationWithIsCritical()
+    {
+        $client = $this->getClient([
+            'token' => getenv('KBC_MANAGE_API_SUPER_TOKEN_WITH_UI_MANAGE_SCOPE'),
+            'url' => getenv('KBC_MANAGE_API_URL'),
+            'backoffMaxTries' => 1,
+        ]);
+
+        $appName = 'Sample critical KBC Application';
+        try {
+            $client->deleteUiApp($appName);
+        } catch (ClientException) {
+        }
+
+        $created = $client->registerUiApp([
+            'manifestUrl' => 'https://keboola.github.io/kbc-ui-app-manifest-file/sample.critical.json',
+            'activate' => true,
+        ]);
+
+        $this->assertEquals(true, $created['version']['isCritical']);
+
+        $apps = $client->listUiApps();
+        $key = array_search($appName, array_column($apps, 'name'));
+
+        $this->assertEquals(true, $apps[$key]['isCritical']);
     }
 
     public function testPublicList()


### PR DESCRIPTION
Jira: CT-1944
Connection PR: keboola/connection#5450

Before asking for review make sure that:

## Checklist

- ~~[ ] New client method(s) has tests~~ No new client method
- ~~[ ] Apiary file is updated~~ In Apiary there is no mention of menifest file structure
- [x] You declared if there is a BC break or not (will affect next release of a client)

## Release

- [x] I gave the PR a proper label:
    * major (BC break)
    * minor (new feature)
    * patch (backwards compatible fix)
    * no release (just test changes)

---

New test checking if new _isCritical_ flag in _manage/ui-apps_  is: 
  - returned when app is registered
  - returned in list of apps

